### PR TITLE
feat(issues): Remove router props from issue list

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -2556,39 +2556,32 @@ function buildRoutes(): RouteObject[] {
     {
       index: true,
       component: errorHandler(OverviewWrapper),
-      deprecatedRouteProps: true,
     },
     {
       path: `${IssueTaxonomy.ERRORS_AND_OUTAGES}/`,
       component: make(() => import('sentry/views/issueList/pages/errorsOutages')),
-      deprecatedRouteProps: true,
     },
     {
       path: `${IssueTaxonomy.BREACHED_METRICS}/`,
       component: make(() => import('sentry/views/issueList/pages/breachedMetrics')),
-      deprecatedRouteProps: true,
     },
     {
       path: `${IssueTaxonomy.WARNINGS}/`,
       component: make(() => import('sentry/views/issueList/pages/warnings')),
-      deprecatedRouteProps: true,
     },
     {
       path: 'views/',
       component: make(
         () => import('sentry/views/issueList/issueViews/issueViewsList/issueViewsList')
       ),
-      deprecatedRouteProps: true,
     },
     {
       path: 'views/:viewId/',
       component: errorHandler(OverviewWrapper),
-      deprecatedRouteProps: true,
     },
     {
       path: 'searches/:searchId/',
       component: errorHandler(OverviewWrapper),
-      deprecatedRouteProps: true,
     },
     // Redirects for legacy tags route.
     {

--- a/static/app/views/issueList/overview.actions.spec.tsx
+++ b/static/app/views/issueList/overview.actions.spec.tsx
@@ -2,7 +2,6 @@ import {Fragment} from 'react';
 import {GroupFixture} from 'sentry-fixture/group';
 import {GroupStatsFixture} from 'sentry-fixture/groupStats';
 import {OrganizationFixture} from 'sentry-fixture/organization';
-import {RouteComponentPropsFixture} from 'sentry-fixture/routeComponentPropsFixture';
 
 import {
   render,
@@ -84,8 +83,6 @@ describe('IssueListOverview (actions)', () => {
     TagStore.init?.();
   });
 
-  const defaultProps = RouteComponentPropsFixture();
-
   describe('status', () => {
     const group1 = GroupFixture({
       id: '1',
@@ -123,7 +120,7 @@ describe('IssueListOverview (actions)', () => {
         method: 'PUT',
       });
 
-      render(<IssueListOverview {...defaultProps} />, {organization});
+      render(<IssueListOverview />, {organization});
 
       const groups = await screen.findAllByTestId('group');
 
@@ -161,7 +158,7 @@ describe('IssueListOverview (actions)', () => {
         method: 'PUT',
       });
 
-      render(<IssueListOverview {...defaultProps} />, {
+      render(<IssueListOverview />, {
         organization,
 
         initialRouterConfig: {
@@ -223,7 +220,7 @@ describe('IssueListOverview (actions)', () => {
 
       render(
         <Fragment>
-          <IssueListOverview {...defaultProps} />
+          <IssueListOverview />
           <Indicators />
         </Fragment>,
         {organization}
@@ -311,7 +308,7 @@ describe('IssueListOverview (actions)', () => {
         method: 'PUT',
       });
 
-      render(<IssueListOverview {...defaultProps} />, {
+      render(<IssueListOverview />, {
         organization,
 
         initialRouterConfig: {
@@ -387,7 +384,7 @@ describe('IssueListOverview (actions)', () => {
         method: 'PUT',
       });
 
-      render(<IssueListOverview {...defaultProps} />, {
+      render(<IssueListOverview />, {
         organization,
       });
 
@@ -430,7 +427,7 @@ describe('IssueListOverview (actions)', () => {
         method: 'PUT',
       });
 
-      render(<IssueListOverview {...defaultProps} />, {
+      render(<IssueListOverview />, {
         organization,
 
         initialRouterConfig: {
@@ -473,7 +470,7 @@ describe('IssueListOverview (actions)', () => {
         method: 'PUT',
       });
 
-      render(<IssueListOverview {...defaultProps} />, {
+      render(<IssueListOverview />, {
         organization,
 
         initialRouterConfig: {

--- a/static/app/views/issueList/overview.polling.spec.tsx
+++ b/static/app/views/issueList/overview.polling.spec.tsx
@@ -1,10 +1,9 @@
 import {GroupFixture} from 'sentry-fixture/group';
 import {GroupStatsFixture} from 'sentry-fixture/groupStats';
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {MemberFixture} from 'sentry-fixture/member';
+import {ProjectFixture} from 'sentry-fixture/project';
 import {TagsFixture} from 'sentry-fixture/tags';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import {textWithMarkupMatcher} from 'sentry-test/utils';
 
@@ -38,26 +37,13 @@ describe('IssueList -> Polling', () => {
     MockApiClient.clearMockResponses();
   });
 
-  const {organization, project, routerProps} = initializeOrg({
-    organization: {
-      access: ['project:releases'],
-    },
-  });
+  const project = ProjectFixture();
   const group = GroupFixture({project});
   const group2 = GroupFixture({project, id: '2'});
 
-  const defaultProps = {
-    location: LocationFixture({
-      query: {query: 'is:unresolved'},
-      search: 'query=is:unresolved',
-    }),
-    params: {},
-    organization,
-  };
-
   /* helpers */
   const renderComponent = async () => {
-    render(<IssueList {...routerProps} {...defaultProps} />, {
+    render(<IssueList />, {
       initialRouterConfig: {
         location: {
           pathname: '/organizations/org-slug/issues/',

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -8,7 +8,6 @@ import {ProjectFixture} from 'sentry-fixture/project';
 import {SearchFixture} from 'sentry-fixture/search';
 import {TagsFixture} from 'sentry-fixture/tags';
 
-import {initializeOrg} from 'sentry-test/initializeOrg';
 import {
   act,
   render,
@@ -22,7 +21,6 @@ import {textWithMarkupMatcher} from 'sentry-test/utils';
 import PageFiltersStore from 'sentry/stores/pageFiltersStore';
 import ProjectsStore from 'sentry/stores/projectsStore';
 import TagStore from 'sentry/stores/tagStore';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import localStorageWrapper from 'sentry/utils/localStorage';
 import * as parseLinkHeader from 'sentry/utils/parseLinkHeader';
 import IssueListOverview from 'sentry/views/issueList/overview';
@@ -39,23 +37,11 @@ const project = ProjectFixture({
   firstEvent: new Date().toISOString(),
 });
 
-const {organization, projects, router} = initializeOrg({
-  organization: {
-    id: '1337',
-    slug: 'org-slug',
-    access: [],
-  },
-  router: {
-    location: {query: {query: DEFAULT_QUERY}},
-    params: {},
-  },
-  projects: [project],
+const organization = OrganizationFixture({
+  id: '1337',
+  slug: 'org-slug',
+  access: [],
 });
-
-const routerProps = {
-  params: router.params,
-  location: router.location,
-} as RouteComponentProps<Record<PropertyKey, string | undefined>, {searchId?: string}>;
 
 const initialRouterConfig = {
   routes: [
@@ -145,7 +131,7 @@ describe('IssueList', () => {
 
     PageFiltersStore.onInitializeUrlState(
       {
-        projects: [parseInt(projects[0]!.id, 10)],
+        projects: [parseInt(project.id, 10)],
         environments: [],
         datetime: {period: '14d', start: null, end: null, utc: null},
       },
@@ -180,7 +166,7 @@ describe('IssueList', () => {
     });
 
     it('loads group uses the provided initial query when no query is in the URL', async () => {
-      render(<IssueListOverview {...routerProps} initialQuery="is:unresolved" />, {
+      render(<IssueListOverview initialQuery="is:unresolved" />, {
         organization,
 
         initialRouterConfig: {
@@ -222,7 +208,7 @@ describe('IssueList', () => {
         ],
       });
 
-      render(<IssueListOverview {...routerProps} />, {
+      render(<IssueListOverview />, {
         organization,
 
         initialRouterConfig: merge({}, initialRouterConfig, {
@@ -265,7 +251,7 @@ describe('IssueList', () => {
         new Set()
       );
 
-      const {unmount} = render(<IssueListOverview {...routerProps} />, {
+      const {unmount} = render(<IssueListOverview />, {
         organization,
 
         initialRouterConfig,
@@ -278,7 +264,7 @@ describe('IssueList', () => {
       unmount();
 
       // Mount component again, getting from cache
-      render(<IssueListOverview {...routerProps} />, {
+      render(<IssueListOverview />, {
         organization,
 
         initialRouterConfig,
@@ -299,7 +285,7 @@ describe('IssueList', () => {
         },
       });
 
-      const {router: testRouter} = render(<IssueListOverview {...routerProps} />, {
+      const {router: testRouter} = render(<IssueListOverview />, {
         organization,
 
         initialRouterConfig,
@@ -380,7 +366,7 @@ describe('IssueList', () => {
         },
       });
 
-      const {router: testRouter} = render(<IssueListOverview {...routerProps} />, {
+      const {router: testRouter} = render(<IssueListOverview />, {
         initialRouterConfig,
       });
 
@@ -401,7 +387,7 @@ describe('IssueList', () => {
   });
 
   it('fetches members', async () => {
-    render(<IssueListOverview {...routerProps} />, {
+    render(<IssueListOverview />, {
       initialRouterConfig,
     });
 
@@ -424,7 +410,7 @@ describe('IssueList', () => {
     });
 
     it('fetches data on selection change', async () => {
-      const {rerender} = render(<IssueListOverview {...routerProps} />, {
+      const {rerender} = render(<IssueListOverview />, {
         initialRouterConfig,
       });
 
@@ -439,7 +425,7 @@ describe('IssueList', () => {
         )
       );
 
-      rerender(<IssueListOverview {...routerProps} />);
+      rerender(<IssueListOverview />);
 
       await waitFor(() => {
         expect(fetchDataMock).toHaveBeenCalled();
@@ -447,7 +433,7 @@ describe('IssueList', () => {
     });
 
     it('uses correct statsPeriod when fetching issues list and no datetime given', async () => {
-      const {rerender} = render(<IssueListOverview {...routerProps} />, {
+      const {rerender} = render(<IssueListOverview />, {
         initialRouterConfig: merge({}, initialRouterConfig, {
           location: {
             query: {
@@ -468,7 +454,7 @@ describe('IssueList', () => {
         )
       );
 
-      rerender(<IssueListOverview {...routerProps} />);
+      rerender(<IssueListOverview />);
 
       await waitFor(() => {
         expect(fetchDataMock).toHaveBeenLastCalledWith(
@@ -483,7 +469,7 @@ describe('IssueList', () => {
 
   describe('componentDidUpdate fetching members', () => {
     it('fetches memberlist on project change', async () => {
-      const {rerender} = render(<IssueListOverview {...routerProps} />, {
+      const {rerender} = render(<IssueListOverview />, {
         initialRouterConfig,
       });
       // Called during componentDidMount
@@ -501,7 +487,7 @@ describe('IssueList', () => {
           new Set()
         )
       );
-      rerender(<IssueListOverview {...routerProps} />);
+      rerender(<IssueListOverview />);
 
       await waitFor(() => {
         expect(fetchMembersRequest).toHaveBeenCalledWith(
@@ -523,7 +509,7 @@ describe('IssueList', () => {
         status: 500,
         statusCode: 500,
       });
-      render(<IssueListOverview {...routerProps} />, {
+      render(<IssueListOverview />, {
         initialRouterConfig,
       });
 
@@ -538,7 +524,7 @@ describe('IssueList', () => {
           Link: DEFAULT_LINKS_HEADER,
         },
       });
-      render(<IssueListOverview {...routerProps} />, {
+      render(<IssueListOverview />, {
         initialRouterConfig,
       });
 
@@ -556,7 +542,7 @@ describe('IssueList', () => {
         },
       });
 
-      const {router: testRouter} = render(<IssueListOverview {...routerProps} />, {
+      const {router: testRouter} = render(<IssueListOverview />, {
         initialRouterConfig: merge({}, initialRouterConfig, {
           location: {
             query: {
@@ -601,7 +587,7 @@ describe('IssueList', () => {
         },
       });
 
-      render(<IssueListOverview {...routerProps} {...moreProps} />, {
+      render(<IssueListOverview {...moreProps} />, {
         organization,
 
         initialRouterConfig,
@@ -812,7 +798,7 @@ describe('IssueList', () => {
       },
     });
 
-    const {rerender} = render(<IssueListOverview {...routerProps} />, {
+    const {rerender} = render(<IssueListOverview />, {
       organization,
 
       initialRouterConfig: merge({}, initialRouterConfig, {
@@ -841,7 +827,7 @@ describe('IssueList', () => {
         href: '',
       },
     });
-    rerender(<IssueListOverview {...routerProps} />);
+    rerender(<IssueListOverview />);
 
     await waitFor(() => {
       expect(screen.getByText(textWithMarkupMatcher('26-50 of 500'))).toBeInTheDocument();
@@ -856,7 +842,7 @@ describe('IssueList', () => {
     it('does not render event processing alert', async () => {
       act(() => ProjectsStore.loadInitialData([project]));
 
-      render(<IssueListOverview {...routerProps} />, {
+      render(<IssueListOverview />, {
         initialRouterConfig,
       });
 
@@ -891,7 +877,7 @@ describe('IssueList', () => {
       });
 
       const {router: testRouter} = render(
-        <IssueListOverview {...routerProps} initialQuery="" shouldFetchOnMount={false} />,
+        <IssueListOverview initialQuery="" shouldFetchOnMount={false} />,
         {
           initialRouterConfig: {
             ...initialRouterConfig,

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -25,7 +25,6 @@ import {space} from 'sentry/styles/space';
 import type {PageFilters} from 'sentry/types/core';
 import type {BaseGroup, Group, PriorityLevel} from 'sentry/types/group';
 import {GroupStatus} from 'sentry/types/group';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import CursorPoller from 'sentry/utils/cursorPoller';
@@ -70,7 +69,7 @@ const DEFAULT_GRAPH_STATS_PERIOD = '24h';
 const DYNAMIC_COUNTS_STATS_PERIODS = new Set(['14d', '24h', 'auto']);
 const MAX_ISSUES_COUNT = 100;
 
-interface Props extends RouteComponentProps<Record<PropertyKey, string | undefined>> {
+interface Props {
   headerActions?: ReactNode;
   initialQuery?: string;
   shouldFetchOnMount?: boolean;

--- a/static/app/views/issueList/overviewWrapper.tsx
+++ b/static/app/views/issueList/overviewWrapper.tsx
@@ -1,20 +1,16 @@
 import {TAXONOMY_DEFAULT_QUERY} from 'sentry/constants';
 import {t} from 'sentry/locale';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import {defined} from 'sentry/utils';
+import {useLocation} from 'sentry/utils/useLocation';
 import useOrganization from 'sentry/utils/useOrganization';
 import IssueListContainer from 'sentry/views/issueList';
 import IssueListOverview from 'sentry/views/issueList/overview';
 
 import {DEFAULT_QUERY} from './utils';
 
-type OverviewWrapperProps = RouteComponentProps<
-  Record<PropertyKey, string | undefined>,
-  {searchId?: string}
->;
-
-export function OverviewWrapper(props: OverviewWrapperProps) {
-  const shouldFetchOnMount = !defined(props.location.query.new);
+export function OverviewWrapper() {
+  const location = useLocation();
+  const shouldFetchOnMount = !defined(location.query.new);
   const organization = useOrganization();
 
   const title = t('Feed');
@@ -26,7 +22,6 @@ export function OverviewWrapper(props: OverviewWrapperProps) {
   return (
     <IssueListContainer title={title}>
       <IssueListOverview
-        {...props}
         shouldFetchOnMount={shouldFetchOnMount}
         title={title}
         initialQuery={defaultQuery}

--- a/static/app/views/issueList/pages/breachedMetrics.tsx
+++ b/static/app/views/issueList/pages/breachedMetrics.tsx
@@ -1,18 +1,15 @@
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import Redirect from 'sentry/components/redirect';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
 import IssueListContainer from 'sentry/views/issueList';
 import IssueListOverview from 'sentry/views/issueList/overview';
 import {ISSUE_TAXONOMY_CONFIG, IssueTaxonomy} from 'sentry/views/issueList/taxonomies';
 
-type Props = RouteComponentProps;
-
 const CONFIG = ISSUE_TAXONOMY_CONFIG[IssueTaxonomy.BREACHED_METRICS];
 const QUERY = `is:unresolved issue.category:[${CONFIG.categories.join(',')}]`;
 
-export default function RegressionsPage(props: Props) {
+export default function RegressionsPage() {
   const organization = useOrganization();
   const hasIssueTaxonomy = organization.features.includes('issue-taxonomy');
   if (!hasIssueTaxonomy) {
@@ -24,7 +21,6 @@ export default function RegressionsPage(props: Props) {
       <PageFiltersContainer>
         <NoProjectMessage organization={organization}>
           <IssueListOverview
-            {...props}
             initialQuery={QUERY}
             title={CONFIG.label}
             titleDescription={CONFIG.description}

--- a/static/app/views/issueList/pages/errorsOutages.tsx
+++ b/static/app/views/issueList/pages/errorsOutages.tsx
@@ -1,19 +1,16 @@
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import Redirect from 'sentry/components/redirect';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
 import IssueListContainer from 'sentry/views/issueList';
 import {MonitorsDropdown} from 'sentry/views/issueList/monitorsDropdown';
 import IssueListOverview from 'sentry/views/issueList/overview';
 import {ISSUE_TAXONOMY_CONFIG, IssueTaxonomy} from 'sentry/views/issueList/taxonomies';
 
-type Props = RouteComponentProps;
-
 const CONFIG = ISSUE_TAXONOMY_CONFIG[IssueTaxonomy.ERRORS_AND_OUTAGES];
 const QUERY = `is:unresolved issue.category:[${CONFIG.categories.join(',')}]`;
 
-export default function ErrorsOutagesPage(props: Props) {
+export default function ErrorsOutagesPage() {
   const organization = useOrganization();
 
   const hasIssueTaxonomy = organization.features.includes('issue-taxonomy');
@@ -26,7 +23,6 @@ export default function ErrorsOutagesPage(props: Props) {
       <PageFiltersContainer>
         <NoProjectMessage organization={organization}>
           <IssueListOverview
-            {...props}
             initialQuery={QUERY}
             title={CONFIG.label}
             titleDescription={CONFIG.description}

--- a/static/app/views/issueList/pages/warnings.tsx
+++ b/static/app/views/issueList/pages/warnings.tsx
@@ -1,18 +1,15 @@
 import NoProjectMessage from 'sentry/components/noProjectMessage';
 import PageFiltersContainer from 'sentry/components/organizations/pageFilters/container';
 import Redirect from 'sentry/components/redirect';
-import type {RouteComponentProps} from 'sentry/types/legacyReactRouter';
 import useOrganization from 'sentry/utils/useOrganization';
 import IssueListContainer from 'sentry/views/issueList';
 import IssueListOverview from 'sentry/views/issueList/overview';
 import {ISSUE_TAXONOMY_CONFIG, IssueTaxonomy} from 'sentry/views/issueList/taxonomies';
 
-type Props = RouteComponentProps;
-
 const CONFIG = ISSUE_TAXONOMY_CONFIG[IssueTaxonomy.WARNINGS];
 const QUERY = `is:unresolved issue.category:[${CONFIG.categories.join(',')}]`;
 
-export default function WarningsPage(props: Props) {
+export default function WarningsPage() {
   const organization = useOrganization();
   const hasIssueTaxonomy = organization.features.includes('issue-taxonomy');
   if (!hasIssueTaxonomy) {
@@ -24,7 +21,6 @@ export default function WarningsPage(props: Props) {
       <PageFiltersContainer>
         <NoProjectMessage organization={organization}>
           <IssueListOverview
-            {...props}
             initialQuery={QUERY}
             title={CONFIG.label}
             titleDescription={CONFIG.description}


### PR DESCRIPTION
Removes the deprecated router props and their corresponding types from the issues list. They were mostly already unused.

part of https://github.com/getsentry/frontend-tsc/issues/93\n\n---\n*Copied from getsentry/sentry#100903*\n*Original PR: https://github.com/getsentry/sentry/pull/100903*