### PR TITLE
Add Prevent to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -686,4 +686,9 @@ pnpm-lock.yaml                                           @getsentry/owners-js-de
 
 # Prevent
 /src/sentry/prevent/                                      @getsentry/prevent
+/src/sentry/overwatch/                                    @getsentry/prevent
+/src/sentry/overwatch_webhooks/                           @getsentry/prevent
+/static/app/components/prevent/                           @getsentry/prevent
+/static/app/views/prevent/                                @getsentry/prevent
+/static/app/views/nav/secondary/sections/prevent/         @getsentry/prevent
 # End of Prevent


### PR DESCRIPTION

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
\n\n---\n*Copied from getsentry/sentry#100897*\n*Original PR: https://github.com/getsentry/sentry/pull/100897*