### PR TITLE
feat(explore): Support numeric attributes in count_unique

### DIFF
--- a/static/app/views/dashboards/datasetConfig/logs.tsx
+++ b/static/app/views/dashboards/datasetConfig/logs.tsx
@@ -90,7 +90,7 @@ const EAP_AGGREGATIONS = LOG_AGGREGATES.map(
         parameters: [
           {
             kind: 'column',
-            columnTypes: ['string'],
+            columnTypes: ['number', 'string'],
             defaultValue: 'message.template',
             required: true,
           },
@@ -299,14 +299,14 @@ function filterAggregateParams(option: FieldValueOption, fieldValue?: QueryField
     return true; // COUNT() doesn't need parameters for logs
   }
 
-  const expectedDataType =
+  const expectedDataTypes =
     fieldValue?.kind === 'function' &&
     fieldValue?.function[0] === AggregationKey.COUNT_UNIQUE
-      ? 'string'
-      : 'number';
+      ? new Set(['number', 'string'])
+      : new Set(['number']);
 
   if ('dataType' in option.value.meta) {
-    return option.value.meta.dataType === expectedDataType;
+    return expectedDataTypes.has(option.value.meta.dataType);
   }
   return true;
 }

--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -105,7 +105,7 @@ const EAP_AGGREGATIONS = ALLOWED_EXPLORE_VISUALIZE_AGGREGATES.reduce(
         parameters: [
           {
             kind: 'column',
-            columnTypes: ['string'],
+            columnTypes: ['number', 'string'],
             defaultValue: 'span.op',
             required: true,
           },

--- a/static/app/views/explore/hooks/useVisualizeFields.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.tsx
@@ -132,7 +132,7 @@ function getSupportedAttributes({
     }
 
     if (functionName === AggregationKey.COUNT_UNIQUE) {
-      return stringTags;
+      return {...numberTags, ...stringTags};
     }
 
     return numberTags;

--- a/static/app/views/explore/logs/logsToolbar.spec.tsx
+++ b/static/app/views/explore/logs/logsToolbar.spec.tsx
@@ -111,9 +111,11 @@ describe('LogsToolbar', () => {
       await userEvent.click(screen.getByRole('option', {name: 'count unique'}));
       await userEvent.click(screen.getByRole('button', {name: 'message'})); // this one isnt remapped for some reason
       options = screen.getAllByRole('option');
-      expect(options).toHaveLength(2);
-      expect(options[0]).toHaveTextContent('message'); // this one isnt remapped for some reason
-      expect(options[1]).toHaveTextContent('severity');
+      expect(options).toHaveLength(4);
+      expect(options[0]).toHaveTextContent('barnumber');
+      expect(options[1]).toHaveTextContent('foonumber');
+      expect(options[2]).toHaveTextContent('message'); // this one isnt remapped for some reason
+      expect(options[3]).toHaveTextContent('severity');
       await userEvent.click(screen.getByRole('option', {name: 'severity'}));
       expect(router.location.query.aggregateField).toEqual(
         [{groupBy: ''}, {yAxes: ['count_unique(severity)']}].map(aggregateField =>

--- a/static/app/views/explore/logs/logsToolbar.tsx
+++ b/static/app/views/explore/logs/logsToolbar.tsx
@@ -211,17 +211,78 @@ function VisualizeDropdown({
   const aggregateParam = visualize.parsedFunction?.arguments?.[0] ?? '';
 
   const fieldOptions = useMemo(() => {
-    return aggregateFunction === AggregationKey.COUNT
-      ? [{label: t('logs'), value: OurLogKnownFieldKey.MESSAGE}]
-      : aggregateFunction === AggregationKey.COUNT_UNIQUE
-        ? sortedStringKeys.map(key => ({
-            label: prettifyTagKey(key),
+    if (aggregateFunction === AggregationKey.COUNT) {
+      return [{label: t('logs'), value: OurLogKnownFieldKey.MESSAGE}];
+    }
+
+    return aggregateFunction === AggregationKey.COUNT_UNIQUE
+      ? [
+          ...sortedNumberKeys.map(key => {
+            const label = prettifyTagKey(key);
+            return {
+              label,
+              value: key,
+              textValue: key,
+              trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
+              showDetailsInOverlay: true,
+              details: (
+                <AttributeDetails
+                  column={key}
+                  kind={FieldKind.MEASUREMENT}
+                  label={label}
+                  traceItemType={TraceItemDataset.LOGS}
+                />
+              ),
+            };
+          }),
+          ...sortedStringKeys.map(key => {
+            const label = prettifyTagKey(key);
+            return {
+              label,
+              value: key,
+              textValue: key,
+              trailingItems: <TypeBadge kind={FieldKind.TAG} />,
+              showDetailsInOverlay: true,
+              details: (
+                <AttributeDetails
+                  column={key}
+                  kind={FieldKind.TAG}
+                  label={label}
+                  traceItemType={TraceItemDataset.LOGS}
+                />
+              ),
+            };
+          }),
+        ].toSorted((a, b) => {
+          const aLabel = prettifyTagKey(a.value);
+          const bLabel = prettifyTagKey(b.value);
+          if (aLabel < bLabel) {
+            return -1;
+          }
+
+          if (aLabel > bLabel) {
+            return 1;
+          }
+          return 0;
+        })
+      : sortedNumberKeys.map(key => {
+          const label = prettifyTagKey(key);
+          return {
+            label,
             value: key,
-          }))
-        : sortedNumberKeys.map(key => ({
-            label: prettifyTagKey(key),
-            value: key,
-          }));
+            textValue: key,
+            trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
+            showDetailsInOverlay: true,
+            details: (
+              <AttributeDetails
+                column={key}
+                kind={FieldKind.MEASUREMENT}
+                label={label}
+                traceItemType={TraceItemDataset.LOGS}
+              />
+            ),
+          };
+        });
   }, [aggregateFunction, sortedStringKeys, sortedNumberKeys]);
 
   const onChangeAggregate = useCallback(
@@ -274,36 +335,42 @@ function ToolbarGroupBy({numberTags, stringTags}: LogsToolbarProps) {
           value: '',
           textValue: '\u2014',
         },
-        ...Object.keys(numberTags ?? {}).map(key => ({
-          label: prettifyTagKey(key),
-          value: key,
-          textValue: key,
-          trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
-          showDetailsInOverlay: true,
-          details: (
-            <AttributeDetails
-              column={key}
-              kind={FieldKind.MEASUREMENT}
-              label={key}
-              traceItemType={TraceItemDataset.LOGS}
-            />
-          ),
-        })),
-        ...Object.keys(stringTags ?? {}).map(key => ({
-          label: prettifyTagKey(key),
-          value: key,
-          textValue: key,
-          trailingItems: <TypeBadge kind={FieldKind.TAG} />,
-          showDetailsInOverlay: true,
-          details: (
-            <AttributeDetails
-              column={key}
-              kind={FieldKind.TAG}
-              label={key}
-              traceItemType={TraceItemDataset.LOGS}
-            />
-          ),
-        })),
+        ...Object.keys(numberTags ?? {}).map(key => {
+          const label = prettifyTagKey(key);
+          return {
+            label,
+            value: key,
+            textValue: key,
+            trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
+            showDetailsInOverlay: true,
+            details: (
+              <AttributeDetails
+                column={key}
+                kind={FieldKind.MEASUREMENT}
+                label={label}
+                traceItemType={TraceItemDataset.LOGS}
+              />
+            ),
+          };
+        }),
+        ...Object.keys(stringTags ?? {}).map(key => {
+          const label = prettifyTagKey(key);
+          return {
+            label,
+            value: key,
+            textValue: key,
+            trailingItems: <TypeBadge kind={FieldKind.TAG} />,
+            showDetailsInOverlay: true,
+            details: (
+              <AttributeDetails
+                column={key}
+                kind={FieldKind.TAG}
+                label={label}
+                traceItemType={TraceItemDataset.LOGS}
+              />
+            ),
+          };
+        }),
       ].toSorted((a, b) => {
         const aLabel = prettifyTagKey(a.value);
         const bLabel = prettifyTagKey(b.value);


### PR DESCRIPTION
Numeric attributes should be permitted as an argument to count_unique.

Requires #100889

Closes for LOGS-398\n\n---\n*Copied from getsentry/sentry#100895*\n*Original PR: https://github.com/getsentry/sentry/pull/100895*