### PR TITLE
fix(tasks): Make retry decorator raise_if_no_retries=False smarter

### DIFF
--- a/src/sentry/tasks/base.py
+++ b/src/sentry/tasks/base.py
@@ -166,8 +166,11 @@ def retry(
             except ignore:
                 return
             except RetryError:
-                # We shouldn't interfere with exceptions that exist to communicate
-                # retry state.
+                if not raise_on_no_retries:
+                    if task_state := current_task():
+                        if not task_state.retries_remaining:
+                            return
+                # If we haven't been asked to ignore no-retries, pass along the RetryError.
                 raise
             except timeout_exceptions:
                 if timeouts:


### PR DESCRIPTION
The expectation with raise_if_no_retries=False is that we will not get NoRetriesRemainingError.
This was already the case for retries generated within the decorator; this extends it so that RetryErrors being caught by the decorator aren't passed through if they'll result in a NoRetriesRemainingError.

---
*Copied from getsentry/sentry#100891*
*Original PR: https://github.com/getsentry/sentry/pull/100891*