### PR TITLE
fix(ui): always render tabs in insights/frontend to avoid flash during first navigation

### DIFF
--- a/static/app/components/route.tsx
+++ b/static/app/components/route.tsx
@@ -17,6 +17,7 @@ interface BaseRouteObject {
    * Including an `Outlet` component as a child element.
    */
   deprecatedRouteProps?: never;
+  handle?: Record<string, unknown>;
   /**
    * Is a index route
    */

--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1870,6 +1870,7 @@ function buildRoutes(): RouteObject[] {
       children: [
         {
           index: true,
+          handle: {module: ModuleName.HTTP},
           component: make(
             () => import('sentry/views/insights/http/views/httpLandingPage')
           ),
@@ -1887,6 +1888,7 @@ function buildRoutes(): RouteObject[] {
       children: [
         {
           index: true,
+          handle: {module: ModuleName.VITAL},
           component: make(
             () =>
               import('sentry/views/insights/browser/webVitals/views/webVitalsLandingPage')
@@ -1905,6 +1907,7 @@ function buildRoutes(): RouteObject[] {
       children: [
         {
           index: true,
+          handle: {module: ModuleName.RESOURCE},
           component: make(
             () =>
               import('sentry/views/insights/browser/resources/views/resourcesLandingPage')
@@ -1985,6 +1988,7 @@ function buildRoutes(): RouteObject[] {
       path: `${MODULE_BASE_URLS[ModuleName.SESSIONS]}/`,
       children: [
         {
+          handle: {module: ModuleName.SESSIONS},
           index: true,
           component: make(() => import('sentry/views/insights/sessions/views/overview')),
         },
@@ -2021,9 +2025,11 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: `${FRONTEND_LANDING_SUB_PATH}/`,
+      component: make(() => import('sentry/views/insights/pages/frontend/layout')),
       children: [
         {
           index: true,
+          handle: {module: undefined},
           component: make(
             () => import('sentry/views/insights/pages/frontend/frontendOverviewPage')
           ),

--- a/static/app/utils/reactRouter6Compat/router.tsx
+++ b/static/app/utils/reactRouter6Compat/router.tsx
@@ -140,7 +140,7 @@ export function translateSentryRoute(tree: SentryRouteObject): RouteObject {
   //   to shim the `useRoutes` hook to act like it did n react-router 3,
   //   where the path was not resolved (looks like /issues/:issueId). Once we
   //   remove usages of useRoutes we can remove this value from the handle.
-  const handle = {name, path};
+  const handle = {...tree.handle, name, path};
 
   if (tree.index) {
     return {index: true, element: getElement(component, deprecatedRouteProps), handle};

--- a/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
+++ b/static/app/views/insights/browser/resources/views/resourcesLandingPage.tsx
@@ -20,7 +20,6 @@ import {ModulesOnboarding} from 'sentry/views/insights/common/components/modules
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
 import {DomainSelector} from 'sentry/views/insights/common/views/spans/selectors/domainSelector';
 import SubregionSelector from 'sentry/views/insights/common/views/spans/selectors/subregionSelector';
-import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {ModuleName} from 'sentry/views/insights/types';
 
 const {SPAN_OP, SPAN_DOMAIN} = BrowserStarfishFields;
@@ -31,7 +30,6 @@ function ResourcesLandingPage() {
   return (
     <React.Fragment>
       <PageAlertProvider>
-        <FrontendHeader module={ModuleName.RESOURCE} />
         <ModuleFeature moduleName={ModuleName.RESOURCE}>
           <Layout.Body>
             <Layout.Main fullWidth>

--- a/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
+++ b/static/app/views/insights/browser/webVitals/views/webVitalsLandingPage.tsx
@@ -23,7 +23,6 @@ import {ModulePageFilterBar} from 'sentry/views/insights/common/components/modul
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModulesOnboarding} from 'sentry/views/insights/common/components/modulesOnboarding';
 import {useWebVitalsDrawer} from 'sentry/views/insights/common/utils/useWebVitalsDrawer';
-import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {ModuleName, SpanFields, type SubregionCode} from 'sentry/views/insights/types';
 
 const WEB_VITALS_COUNT = 5;
@@ -68,8 +67,6 @@ function WebVitalsLandingPage() {
 
   return (
     <React.Fragment>
-      <FrontendHeader module={ModuleName.VITAL} />
-
       <ModuleFeature moduleName={ModuleName.VITAL}>
         <Layout.Body>
           <Layout.Main fullWidth>

--- a/static/app/views/insights/http/views/httpLandingPage.tsx
+++ b/static/app/views/insights/http/views/httpLandingPage.tsx
@@ -30,8 +30,6 @@ import {
 import {Referrer} from 'sentry/views/insights/http/referrers';
 import {BackendHeader} from 'sentry/views/insights/pages/backend/backendPageHeader';
 import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backend/settings';
-import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
-import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
 import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
@@ -105,7 +103,6 @@ export function HTTPLandingPage() {
 
   return (
     <React.Fragment>
-      {view === FRONTEND_LANDING_SUB_PATH && <FrontendHeader {...headerProps} />}
       {view === BACKEND_LANDING_SUB_PATH && <BackendHeader {...headerProps} />}
       {view === MOBILE_LANDING_SUB_PATH && <MobileHeader {...headerProps} />}
 

--- a/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
+++ b/static/app/views/insights/pages/frontend/frontendOverviewPage.tsx
@@ -41,13 +41,11 @@ import {
   isAValidSort,
   type ValidSort,
 } from 'sentry/views/insights/pages/frontend/frontendOverviewTable';
-import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {useFrontendTableData} from 'sentry/views/insights/pages/frontend/queries/useFrontendTableData';
 import type {PageSpanOps} from 'sentry/views/insights/pages/frontend/settings';
 import {
   DEFAULT_SORT,
   DEFAULT_SPAN_OP_SELECTION,
-  FRONTEND_LANDING_TITLE,
   PAGE_SPAN_OPS,
   SPAN_OP_QUERY_PARAM,
 } from 'sentry/views/insights/pages/frontend/settings';
@@ -143,7 +141,6 @@ function FrontendOverviewPage() {
       organization={organization}
       renderDisabled={NoAccess}
     >
-      <FrontendHeader headerTitle={FRONTEND_LANDING_TITLE} />
       <Layout.Body>
         <Layout.Main fullWidth>
           <ModuleLayout.Layout>

--- a/static/app/views/insights/pages/frontend/layout.tsx
+++ b/static/app/views/insights/pages/frontend/layout.tsx
@@ -1,0 +1,18 @@
+import {Fragment} from 'react';
+import {Outlet, useMatches} from 'react-router-dom';
+
+import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
+import {ModuleName} from 'sentry/views/insights/types';
+
+function FrontendLayout() {
+  const handle = useMatches().at(-1)?.handle as {module?: ModuleName} | undefined;
+
+  return (
+    <Fragment>
+      {handle && 'module' in handle ? <FrontendHeader module={handle.module} /> : null}
+      <Outlet />
+    </Fragment>
+  );
+}
+
+export default FrontendLayout;

--- a/static/app/views/insights/sessions/views/overview.tsx
+++ b/static/app/views/insights/sessions/views/overview.tsx
@@ -11,7 +11,6 @@ import * as ModuleLayout from 'sentry/views/insights/common/components/moduleLay
 import {ModulePageProviders} from 'sentry/views/insights/common/components/modulePageProviders';
 import {ModulesOnboardingPanel} from 'sentry/views/insights/common/components/modulesOnboarding';
 import {ToolRibbon} from 'sentry/views/insights/common/components/ribbon';
-import {FrontendHeader} from 'sentry/views/insights/pages/frontend/frontendPageHeader';
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import {MobileHeader} from 'sentry/views/insights/pages/mobile/mobilePageHeader';
 import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
@@ -65,8 +64,6 @@ function SessionsOverview() {
 
 function ViewSpecificHeader({view}: {view: DomainView | ''}) {
   switch (view) {
-    case FRONTEND_LANDING_SUB_PATH:
-      return <FrontendHeader module={ModuleName.SESSIONS} />;
     case MOBILE_LANDING_SUB_PATH:
       return <MobileHeader module={ModuleName.SESSIONS} />;
     default:


### PR DESCRIPTION
In the current UI, wherever we use top-level tabs, we can see a full flash of an empty page when doing the first navigation, which is pretty annoying and not great UX:

https://github.com/user-attachments/assets/50d21116-488d-416f-b0a2-fdb581288a58

The technical problem is that we lazy-load each route, but each route is also responsible for rendering its own tabs. That means when we navigate through the tabs, the tabs unmount.

This PR introduces a solution where we use [nested layouts](https://reactrouter.com/start/declarative/routing#layout-routes) to render the tabs instead of having the tabs be part of each separate page.

That means the tabs will stay mounted while only its content lazy-loads, which leads to a lot better UX:

https://github.com/user-attachments/assets/eeaf7d63-6d61-4387-926a-c6fe45f9c7bf

Technically, we render a `layout.tsx` file at the root of `/frontend`, which will render the `<FrontendHeader>` for all sub-routes plus an `<Outlet>` for the children.

The problem is that the layout must know which “child” it is going to render in order to select the current tab.
With [useMatches](https://reactrouter.com/api/hooks/useMatches#usematches), we can take a look at what renders at runtime, and then “inspect” the last match to see what child it is. We could just look at the url path segment but that’s a bit brittle, so I opted for using [route handles](https://reactrouter.com/how-to/using-handle).

Route handles are often used to build dynamic UI elements like breadcrumbs based on the route hierarchy. Here, we just use it to pass custom information from the route tree (where we define our routes) to the layout, so that it knows what to do. In this case, we pass the `ModuleName` of the rendered page so that we can pass that to the `<FrontendHeader>` component. This sadly isn’t type-safe (react-router doesn’t do type-safety like that), but I think this is a fine trade-off.

---
*Copied from getsentry/sentry#100915*
*Original PR: https://github.com/getsentry/sentry/pull/100915*