### PR TITLE
fix(explore): Improve improvement of conversion to `TimeSeries`

### DIFF
--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -292,5 +292,5 @@ export function convertEventsStatsToTimeSeriesData(
     delayedTimeSeries.meta.order = order;
   }
 
-  return [timeSeries.meta.order ?? 0, timeSeries];
+  return [timeSeries.meta.order ?? 0, delayedTimeSeries];
 }


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/100532, with a few small fixes:

- Always assign `isOther`, if it's a `groupBy`
- Use `groupData` for order rather than the event data
- Mark delayed data

Supports ENG-5608

---
*Copied from getsentry/sentry#100918*
*Original PR: https://github.com/getsentry/sentry/pull/100918*