### PR TITLE
fix(releases): Fix new groups count per project for a release

### DIFF
--- a/src/sentry/releases/use_cases/release.py
+++ b/src/sentry/releases/use_cases/release.py
@@ -430,7 +430,7 @@ def fetch_issue_count(
         qs1 = ReleaseProjectEnvironment.objects.filter(release_id__in=release_ids)
         qs1 = qs1.filter(environment_id__in=environment_ids)
         qs1 = qs1.filter(project_id__in=project_ids)
-        qs1 = qs1.annotate(new_groups=Sum("new_issues_count"))
+        qs1 = qs1.values("project_id", "release_id").annotate(new_groups=Sum("new_issues_count"))
         return list(qs1.values_list("project_id", "release_id", "new_groups"))
     else:
         qs2 = ReleaseProject.objects.filter(release_id__in=release_ids)

--- a/src/sentry/releases/use_cases/release.py
+++ b/src/sentry/releases/use_cases/release.py
@@ -74,13 +74,7 @@ def serialize(
         fetch_owners=lambda owner_ids: fetch_owners(user, owner_ids),
     )
 
-    # project_map = get_projects_old(projects, new_groups_map.values(), fetch_project_platforms)
     project_map = get_projects(projects, fetch_project_platforms)
-
-    # release_projects_map = {
-    #     release_id: [project_map[project_id] for project_id in mapping.keys()]
-    #     for release_id, mapping in new_groups_map.items()
-    # }
 
     release_projects_map = {
         release_id: [
@@ -140,35 +134,6 @@ def get_projects(
             "slug": project.slug,
             "name": project.name,
             "platform": project.platform,
-            "platforms": platforms[project.id],
-            "hasHealthData": False,
-        }
-        for project in projects
-    }
-
-
-@sentry_sdk.trace
-def get_projects_old(
-    projects: Iterable[Project],
-    project_group_counts: Iterable[dict[int, int]],
-    fetch_platforms: Callable[[Iterable[int]], list[tuple[int, str]]],
-) -> dict[int, SerializedProject]:
-    platforms = defaultdict(list)
-    for project_id, platform in fetch_platforms([p.id for p in projects]):
-        platforms[project_id].append(platform)
-
-    new_groups: defaultdict[int, int] = defaultdict(int)
-    for mapping in project_group_counts:
-        for project_id, count in mapping.items():
-            new_groups[project_id] += count
-
-    return {
-        project.id: {
-            "id": project.id,
-            "slug": project.slug,
-            "name": project.name,
-            "platform": project.platform,
-            "newGroups": new_groups[project.id],
             "platforms": platforms[project.id],
             "hasHealthData": False,
         }

--- a/src/sentry/releases/use_cases/release.py
+++ b/src/sentry/releases/use_cases/release.py
@@ -76,15 +76,7 @@ def serialize(
 
     project_map = get_projects(projects, fetch_project_platforms)
 
-    release_projects_map = {}
-    for release_id, mapping in new_groups_map.items():
-        projects_for_release = []
-        for project_id, count in mapping.items():
-            if count is not None and count > 0:  # Only include projects with actual new groups
-                project_data = project_map[project_id].copy()
-                project_data["newGroups"] = count
-                projects_for_release.append(project_data)
-        release_projects_map[release_id] = projects_for_release
+    release_projects_map = get_release_projects_map(new_groups_map, project_map)
 
     adoption_stage_map: dict[int, dict[str, AdoptionStage]] = {
         rid: {project_map[pid]["slug"]: adoption_stage for pid, adoption_stage in mapping}
@@ -143,6 +135,23 @@ def get_projects(
         }
         for project in projects
     }
+
+
+@sentry_sdk.trace
+def get_release_projects_map(
+    new_groups_map: dict[int, dict[int, int | None]],
+    project_map: dict[int, SerializedProject],
+) -> dict[int, list[SerializedProject]]:
+    release_projects_map = {}
+    for release_id, mapping in new_groups_map.items():
+        projects_for_release = []
+        for project_id, count in mapping.items():
+            if count is not None and count > 0:  # Only include projects with actual new groups
+                project_data = project_map[project_id].copy()
+                project_data["newGroups"] = count
+                projects_for_release.append(project_data)
+        release_projects_map[release_id] = projects_for_release
+    return release_projects_map
 
 
 @sentry_sdk.trace

--- a/src/sentry/releases/use_cases/release.py
+++ b/src/sentry/releases/use_cases/release.py
@@ -76,12 +76,15 @@ def serialize(
 
     project_map = get_projects(projects, fetch_project_platforms)
 
-    release_projects_map = {
-        release_id: [
-            {**project_map[project_id], "newGroups": count} for project_id, count in mapping.items()
-        ]
-        for release_id, mapping in new_groups_map.items()
-    }
+    release_projects_map = {}
+    for release_id, mapping in new_groups_map.items():
+        projects_for_release = []
+        for project_id, count in mapping.items():
+            if count is not None and count > 0:  # Only include projects with actual new groups
+                project_data = project_map[project_id].copy()
+                project_data["newGroups"] = count
+                projects_for_release.append(project_data)
+        release_projects_map[release_id] = projects_for_release
 
     adoption_stage_map: dict[int, dict[str, AdoptionStage]] = {
         rid: {project_map[pid]["slug"]: adoption_stage for pid, adoption_stage in mapping}
@@ -134,6 +137,7 @@ def get_projects(
             "slug": project.slug,
             "name": project.name,
             "platform": project.platform,
+            "newGroups": 0,  # Default value, will be overridden per release
             "platforms": platforms[project.id],
             "hasHealthData": False,
         }

--- a/src/sentry/releases/use_cases/release.py
+++ b/src/sentry/releases/use_cases/release.py
@@ -74,6 +74,7 @@ def serialize(
         fetch_owners=lambda owner_ids: fetch_owners(user, owner_ids),
     )
 
+    # project_map = get_projects_old(projects, new_groups_map.values(), fetch_project_platforms)
     project_map = get_projects(projects, fetch_project_platforms)
 
     # release_projects_map = {
@@ -81,15 +82,12 @@ def serialize(
     #     for release_id, mapping in new_groups_map.items()
     # }
 
-    release_projects_map = {}
-    for release_id, mapping in new_groups_map.items():
-        projects_for_release = [project_map[project_id] for project_id in mapping.keys()]
-
-        # get the new groups for each project only for this release
-        for project_data in projects_for_release:
-            project_data["newGroups"] = mapping[project_data["id"]]
-
-        release_projects_map[release_id] = projects_for_release
+    release_projects_map = {
+        release_id: [
+            {**project_map[project_id], "newGroups": count} for project_id, count in mapping.items()
+        ]
+        for release_id, mapping in new_groups_map.items()
+    }
 
     adoption_stage_map: dict[int, dict[str, AdoptionStage]] = {
         rid: {project_map[pid]["slug"]: adoption_stage for pid, adoption_stage in mapping}
@@ -130,17 +128,11 @@ def serialize(
 @sentry_sdk.trace
 def get_projects(
     projects: Iterable[Project],
-    # project_group_counts: Iterable[dict[int, int]],
     fetch_platforms: Callable[[Iterable[int]], list[tuple[int, str]]],
 ) -> dict[int, SerializedProject]:
     platforms = defaultdict(list)
     for project_id, platform in fetch_platforms([p.id for p in projects]):
         platforms[project_id].append(platform)
-
-    # new_groups: defaultdict[int, int] = defaultdict(int)
-    # for mapping in project_group_counts:
-    #     for project_id, count in mapping.items():
-    #         new_groups[project_id] += count
 
     return {
         project.id: {
@@ -148,7 +140,35 @@ def get_projects(
             "slug": project.slug,
             "name": project.name,
             "platform": project.platform,
-            # "newGroups": new_groups[project.id],
+            "platforms": platforms[project.id],
+            "hasHealthData": False,
+        }
+        for project in projects
+    }
+
+
+@sentry_sdk.trace
+def get_projects_old(
+    projects: Iterable[Project],
+    project_group_counts: Iterable[dict[int, int]],
+    fetch_platforms: Callable[[Iterable[int]], list[tuple[int, str]]],
+) -> dict[int, SerializedProject]:
+    platforms = defaultdict(list)
+    for project_id, platform in fetch_platforms([p.id for p in projects]):
+        platforms[project_id].append(platform)
+
+    new_groups: defaultdict[int, int] = defaultdict(int)
+    for mapping in project_group_counts:
+        for project_id, count in mapping.items():
+            new_groups[project_id] += count
+
+    return {
+        project.id: {
+            "id": project.id,
+            "slug": project.slug,
+            "name": project.name,
+            "platform": project.platform,
+            "newGroups": new_groups[project.id],
             "platforms": platforms[project.id],
             "hasHealthData": False,
         }

--- a/src/sentry/releases/use_cases/release.py
+++ b/src/sentry/releases/use_cases/release.py
@@ -78,9 +78,7 @@ def serialize(
 
     release_projects_map = {
         release_id: [
-            {**project_map[project_id], "newGroups": count}
-            for project_id, count in mapping.items()
-            if count is not None and count > 0
+            {**project_map[project_id], "newGroups": count} for project_id, count in mapping.items()
         ]
         for release_id, mapping in new_groups_map.items()
     }

--- a/tests/sentry/releases/use_cases/test_release_serializer.py
+++ b/tests/sentry/releases/use_cases/test_release_serializer.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from sentry.models.release import Release
+from sentry.models.releases.release_project import ReleaseProject
+from sentry.releases.use_cases.release import serialize as release_serializer
+from sentry.testutils.cases import TestCase
+
+
+class ReleaseSerializerUseCaseTest(TestCase):
+    """
+    Tests for the releases.use_cases.release.serialize function.
+
+    This tests the NEW serializer that fixes the per-project newGroups calculation,
+    as opposed to the old model-based serializer in api.serializers.models.release.
+    """
+
+    def test_new_groups_single_release_per_project(self):
+        """
+        Test new groups counts for one release with multiple projects, each having different issue counts.
+        """
+        project_a = self.create_project(name="Project A", slug="project-a")
+        project_b = self.create_project(
+            name="Project B", slug="project-b", organization=project_a.organization
+        )
+
+        # Create release in projects A and B
+        release_version = "1.0.0"
+        release = Release.objects.create(
+            organization_id=project_a.organization_id, version=release_version
+        )
+        release.add_project(project_a)
+        release.add_project(project_b)
+
+        # 3 new groups for project A, 2 new groups for project B
+        ReleaseProject.objects.filter(release=release, project=project_a).update(new_groups=3)
+        ReleaseProject.objects.filter(release=release, project=project_b).update(new_groups=2)
+
+        result = release_serializer(
+            releases=[release],
+            user=self.user,
+            organization_id=project_a.organization_id,
+            environment_ids=[],  # No environment filtering
+            projects=[project_a, project_b],
+        )
+
+        assert len(result) == 1
+        serialized_release = result[0]
+
+        # total new groups count (5 == 3 + 2)
+        assert serialized_release["newGroups"] == 5
+
+        # new groups count for each project (3 for A, 2 for B)
+        projects_by_id = {p["id"]: p for p in serialized_release["projects"]}
+        assert projects_by_id[project_a.id]["newGroups"] == 3
+        assert projects_by_id[project_b.id]["newGroups"] == 2
+
+        assert projects_by_id[project_a.id]["name"] == "Project A"
+        assert projects_by_id[project_a.id]["slug"] == "project-a"
+        assert projects_by_id[project_b.id]["name"] == "Project B"
+        assert projects_by_id[project_b.id]["slug"] == "project-b"
+
+    def test_multiple_releases_per_project_isolation(self):
+        """
+        Test new groups count for multiple releases per project.
+        """
+        project_a = self.create_project(name="Project A", slug="project-a")
+        project_b = self.create_project(
+            name="Project B", slug="project-b", organization=project_a.organization
+        )
+
+        # Create releases 1 and 2, both in projects A and B
+        release_1 = Release.objects.create(
+            organization_id=project_a.organization_id, version="1.0.0"
+        )
+        release_1.add_project(project_a)
+        release_1.add_project(project_b)
+        release_2 = Release.objects.create(
+            organization_id=project_a.organization_id, version="2.0.0"
+        )
+        release_2.add_project(project_a)
+        release_2.add_project(project_b)
+
+        # Release 1.0.0 has 3 new groups for project A, 2 new groups for project B
+        ReleaseProject.objects.filter(release=release_1, project=project_a).update(new_groups=3)
+        ReleaseProject.objects.filter(release=release_1, project=project_b).update(new_groups=2)
+
+        # Release 2.0.0 has 1 new groups for project A, 4 new groups for project B
+        ReleaseProject.objects.filter(release=release_2, project=project_a).update(new_groups=1)
+        ReleaseProject.objects.filter(release=release_2, project=project_b).update(new_groups=4)
+
+        # 1. Serialize Release 1.0.0 ONLY
+        result_1 = release_serializer(
+            releases=[release_1],
+            user=self.user,
+            organization_id=project_a.organization_id,
+            environment_ids=[],
+            projects=[project_a, project_b],
+        )
+
+        assert len(result_1) == 1
+        release_1_data = result_1[0]
+        assert release_1_data["version"] == "1.0.0"
+        assert release_1_data["newGroups"] == 5  # total new groups count (5 == 3 + 2)
+        projects_1_by_id = {p["id"]: p for p in release_1_data["projects"]}
+        # new groups count for each project (3 for A, 2 for B)
+        assert projects_1_by_id[project_a.id]["newGroups"] == 3
+        assert projects_1_by_id[project_b.id]["newGroups"] == 2
+
+        # 2. Serialize Release 2.0.0 ONLY
+        result_2 = release_serializer(
+            releases=[release_2],
+            user=self.user,
+            organization_id=project_a.organization_id,
+            environment_ids=[],
+            projects=[project_a, project_b],
+        )
+
+        assert len(result_2) == 1
+        release_2_data = result_2[0]
+        assert release_2_data["version"] == "2.0.0"
+        assert release_2_data["newGroups"] == 5  # total new groups count (5 == 1 + 4)
+        projects_2_by_id = {p["id"]: p for p in release_2_data["projects"]}
+        # new groups count for each project (1 for A, 4 for B)
+        assert projects_2_by_id[project_a.id]["newGroups"] == 1
+        assert projects_2_by_id[project_b.id]["newGroups"] == 4
+
+        # 3. Serialize both releases together
+        result_both = release_serializer(
+            releases=[release_1, release_2],
+            user=self.user,
+            organization_id=project_a.organization_id,
+            environment_ids=[],
+            projects=[project_a, project_b],
+        )
+
+        assert len(result_both) == 2
+
+        # Find each release in the results
+        releases_by_version = {r["version"]: r for r in result_both}
+        both_release_1 = releases_by_version["1.0.0"]
+        both_release_2 = releases_by_version["2.0.0"]
+
+        # Verify that when serialized together, counts are still isolated per release
+        both_projects_1_by_id = {p["id"]: p for p in both_release_1["projects"]}
+        both_projects_2_by_id = {p["id"]: p for p in both_release_2["projects"]}
+        # Release 1.0.0 should still have its isolated counts
+        assert both_projects_1_by_id[project_a.id]["newGroups"] == 3
+        assert both_projects_1_by_id[project_b.id]["newGroups"] == 2
+        # Release 2.0.0 should still have its isolated counts
+        assert both_projects_2_by_id[project_a.id]["newGroups"] == 1
+        assert both_projects_2_by_id[project_b.id]["newGroups"] == 4
+
+    def test_environment_filtering_per_project(self):
+        """
+        Test environment filtering with per-project counts.
+
+        Scenario:
+        - Release "1.0.0" in Project A: 3 issues in production, 1 issue in staging
+        - Release "1.0.0" in Project B: 2 issues in production, 0 issues in staging
+        - When filtering by production: Project A = 3, Project B = 2
+        - When filtering by staging: Project A = 1, Project B = 0
+        - When no environment filter: Project A = 3, Project B = 2 (uses ReleaseProject.new_groups)
+
+        This verifies environment filtering works correctly with our fix.
+        """
+        # TODO: Implement test
+        pass
+
+    def test_cross_project_release_environment_complex(self):
+        """
+        Test complex scenario: Multiple releases, projects, and environments.
+
+        Scenario:
+        - Release "1.0.0":
+          - Project A: 3 issues in production, 1 issue in staging
+          - Project B: 2 issues in production, 0 issues in staging
+        - Release "2.0.0":
+          - Project A: 1 issue in production, 2 issues in staging
+          - Project B: 4 issues in production, 1 issue in staging
+
+        When serializing Release "1.0.0" with production filter:
+        - Should return: Project A = 3, Project B = 2
+        - Should NOT include counts from Release "2.0.0"
+
+        This is the most comprehensive test of our fix.
+        """
+        # TODO: Implement test
+        pass
+
+    # def test_model_counts_vs_serializer_consistency(self):
+    #     """
+    #     Test that our serializer produces consistent results with model counts.
+
+    #     Scenario:
+    #     - Create releases and projects with known issue counts
+    #     - Force buffer processing to update ReleaseProject.new_groups and ReleaseProjectEnvironment.new_issues_count
+    #     - Compare serializer output with direct model queries
+    #     - Verify they match after buffer processing
+
+    #     This ensures our fix maintains consistency with the underlying model data.
+    #     """
+    #     # TODO: Implement test
+    #     pass
+
+    def test_backward_compatibility_release_level_totals(self):
+        """
+        Test that release-level totals (release.newGroups) remain unchanged.
+
+        Scenario:
+        - Create multiple projects with different issue counts
+        - Verify that release.newGroups still equals sum of all project counts
+        - Ensure existing frontend code that uses release.newGroups continues to work
+
+        This ensures our fix doesn't break existing functionality.
+        """
+        # TODO: Implement test
+        pass
+
+    def test_empty_and_edge_cases(self):
+        """
+        Test edge cases: empty projects, zero counts, missing data.
+
+        Scenarios:
+        - Release with no projects
+        - Release with projects but zero new issues
+        - Release with missing ReleaseProject records
+        - Release with None values in new_groups fields
+
+        This ensures our fix handles edge cases gracefully.
+        """
+        # TODO: Implement test
+        pass

--- a/tests/sentry/releases/use_cases/test_release_serializer.py
+++ b/tests/sentry/releases/use_cases/test_release_serializer.py
@@ -51,14 +51,14 @@ class ReleaseSerializerUseCaseTest(TestCase):
         assert serialized_release["newGroups"] == 5
 
         # new groups count for each project (3 for A, 2 for B)
-        projects_by_id = {p["id"]: p for p in serialized_release["projects"]}
-        assert projects_by_id[project_a.id]["newGroups"] == 3
-        assert projects_by_id[project_b.id]["newGroups"] == 2
+        projects = {p["id"]: p for p in serialized_release["projects"]}
+        assert projects[project_a.id]["newGroups"] == 3
+        assert projects[project_b.id]["newGroups"] == 2
 
-        assert projects_by_id[project_a.id]["name"] == "Project A"
-        assert projects_by_id[project_a.id]["slug"] == "project-a"
-        assert projects_by_id[project_b.id]["name"] == "Project B"
-        assert projects_by_id[project_b.id]["slug"] == "project-b"
+        assert projects[project_a.id]["name"] == "Project A"
+        assert projects[project_a.id]["slug"] == "project-a"
+        assert projects[project_b.id]["name"] == "Project B"
+        assert projects[project_b.id]["slug"] == "project-b"
 
     def test_new_groups_multiple_releases_per_project(self):
         """
@@ -89,67 +89,66 @@ class ReleaseSerializerUseCaseTest(TestCase):
         ReleaseProject.objects.filter(release=release_2, project=project_a).update(new_groups=1)
         ReleaseProject.objects.filter(release=release_2, project=project_b).update(new_groups=4)
 
-        # 1. Serialize Release 1.0.0 ONLY
-        result_1 = release_serializer(
+        # 1. Serialize Release 1.0.0
+        result = release_serializer(
             releases=[release_1],
             user=self.user,
             organization_id=project_a.organization_id,
             environment_ids=[],
             projects=[project_a, project_b],
         )
-
-        assert len(result_1) == 1
-        release_1_data = result_1[0]
-        assert release_1_data["version"] == "1.0.0"
-        assert release_1_data["newGroups"] == 5  # total new groups count (5 == 3 + 2)
-        projects_1_by_id = {p["id"]: p for p in release_1_data["projects"]}
+        assert len(result) == 1
+        serialized_release = result[0]
+        assert serialized_release["version"] == "1.0.0"
+        assert serialized_release["newGroups"] == 5  # total new groups count (5 == 3 + 2)
+        projects = {p["id"]: p for p in serialized_release["projects"]}
         # new groups count for each project (3 for A, 2 for B)
-        assert projects_1_by_id[project_a.id]["newGroups"] == 3
-        assert projects_1_by_id[project_b.id]["newGroups"] == 2
+        assert projects[project_a.id]["newGroups"] == 3
+        assert projects[project_b.id]["newGroups"] == 2
 
-        # 2. Serialize Release 2.0.0 ONLY
-        result_2 = release_serializer(
+        # 2. Serialize Release 2.0.0
+        result = release_serializer(
             releases=[release_2],
             user=self.user,
             organization_id=project_a.organization_id,
             environment_ids=[],
             projects=[project_a, project_b],
         )
-
-        assert len(result_2) == 1
-        release_2_data = result_2[0]
-        assert release_2_data["version"] == "2.0.0"
-        assert release_2_data["newGroups"] == 5  # total new groups count (5 == 1 + 4)
-        projects_2_by_id = {p["id"]: p for p in release_2_data["projects"]}
+        assert len(result) == 1
+        serialized_release = result[0]
+        assert serialized_release["version"] == "2.0.0"
+        assert serialized_release["newGroups"] == 5  # total new groups count (5 == 1 + 4)
+        projects = {p["id"]: p for p in serialized_release["projects"]}
         # new groups count for each project (1 for A, 4 for B)
-        assert projects_2_by_id[project_a.id]["newGroups"] == 1
-        assert projects_2_by_id[project_b.id]["newGroups"] == 4
+        assert projects[project_a.id]["newGroups"] == 1
+        assert projects[project_b.id]["newGroups"] == 4
 
         # 3. Serialize both releases together
-        result_both = release_serializer(
+        result = release_serializer(
             releases=[release_1, release_2],
             user=self.user,
             organization_id=project_a.organization_id,
             environment_ids=[],
             projects=[project_a, project_b],
         )
-
-        assert len(result_both) == 2
-
-        # Verify that when serialized together, counts are still isolated per release
-        releases_by_version = {r["version"]: r for r in result_both}
-        both_release_1 = releases_by_version["1.0.0"]
-        both_release_2 = releases_by_version["2.0.0"]
-        both_projects_1_by_id = {p["id"]: p for p in both_release_1["projects"]}
-        both_projects_2_by_id = {p["id"]: p for p in both_release_2["projects"]}
-        assert both_projects_1_by_id[project_a.id]["newGroups"] == 3
-        assert both_projects_1_by_id[project_b.id]["newGroups"] == 2
-        assert both_projects_2_by_id[project_a.id]["newGroups"] == 1
-        assert both_projects_2_by_id[project_b.id]["newGroups"] == 4
+        assert len(result) == 2
+        serialized_releases = {r["version"]: r for r in result}
+        serialized_release_1 = serialized_releases["1.0.0"]
+        serialized_release_2 = serialized_releases["2.0.0"]
+        # both new group counts should be 5
+        assert serialized_release_1["newGroups"] == 5
+        assert serialized_release_2["newGroups"] == 5
+        # new groups counts for each project
+        projects_1 = {p["id"]: p for p in serialized_release_1["projects"]}
+        projects_2 = {p["id"]: p for p in serialized_release_2["projects"]}
+        assert projects_1[project_a.id]["newGroups"] == 3
+        assert projects_1[project_b.id]["newGroups"] == 2
+        assert projects_2[project_a.id]["newGroups"] == 1
+        assert projects_2[project_b.id]["newGroups"] == 4
 
     def test_new_groups_environment_filtering(self):
         """
-        Test new group counts withenvironment filtering.
+        Test new group counts for a single release with environment filtering.
         """
         project_a = self.create_project(name="Project A", slug="project-a")
         project_b = self.create_project(
@@ -181,80 +180,186 @@ class ReleaseSerializerUseCaseTest(TestCase):
         )
 
         # 1. No environment filter
-        result_no_env = release_serializer(
+        result = release_serializer(
             releases=[release],
             user=self.user,
             organization_id=project_a.organization_id,
             environment_ids=[],
             projects=[project_a, project_b],
         )
-        assert len(result_no_env) == 1
-        release_data_no_env = result_no_env[0]
-        projects_no_env = {p["id"]: p for p in release_data_no_env["projects"]}
-        assert projects_no_env[project_a.id]["newGroups"] == 4
-        assert projects_no_env[project_b.id]["newGroups"] == 2
-        assert release_data_no_env["newGroups"] == 6
+        assert len(result) == 1
+        serialized_release = result[0]
+        projects = {p["id"]: p for p in serialized_release["projects"]}
+        assert projects[project_a.id]["newGroups"] == 4
+        assert projects[project_b.id]["newGroups"] == 2
+        assert serialized_release["newGroups"] == 6
 
         # 2. Filter by production environment
-        result_production = release_serializer(
+        result = release_serializer(
             releases=[release],
             user=self.user,
             organization_id=project_a.organization_id,
             environment_ids=[production.id],
             projects=[project_a, project_b],
         )
-        assert len(result_production) == 1
-        release_data_production = result_production[0]
-        projects_production = {p["id"]: p for p in release_data_production["projects"]}
-        assert projects_production[project_a.id]["newGroups"] == 3
-        assert projects_production[project_b.id]["newGroups"] == 2
-        assert release_data_production["newGroups"] == 5
+        assert len(result) == 1
+        serialized_release = result[0]
+        projects = {p["id"]: p for p in serialized_release["projects"]}
+        assert projects[project_a.id]["newGroups"] == 3
+        assert projects[project_b.id]["newGroups"] == 2
+        assert serialized_release["newGroups"] == 5
 
         # 3. Filter by staging environment
-        result_staging = release_serializer(
+        result = release_serializer(
             releases=[release],
             user=self.user,
             organization_id=project_a.organization_id,
-            environment_ids=[staging.id],  # Staging only
+            environment_ids=[staging.id],
             projects=[project_a, project_b],
         )
-        assert len(result_staging) == 1
-        release_data_staging = result_staging[0]
-        projects_staging = {p["id"]: p for p in release_data_staging["projects"]}
-        assert projects_staging[project_a.id]["newGroups"] == 1
-        assert project_b.id not in projects_staging
-        assert release_data_staging["newGroups"] == 1
+        assert len(result) == 1
+        serialized_release = result[0]
+        projects = {p["id"]: p for p in serialized_release["projects"]}
+        assert projects[project_a.id]["newGroups"] == 1
+        assert project_b.id not in projects
+        assert serialized_release["newGroups"] == 1
 
         # 4. Filter by both environments
-        result_both_envs = release_serializer(
+        result = release_serializer(
             releases=[release],
             user=self.user,
             organization_id=project_a.organization_id,
             environment_ids=[production.id, staging.id],
             projects=[project_a, project_b],
         )
-        assert len(result_both_envs) == 1
-        release_data_both_envs = result_both_envs[0]
-        projects_both_envs = {p["id"]: p for p in release_data_both_envs["projects"]}
-        assert projects_both_envs[project_a.id]["newGroups"] == 4
-        assert projects_both_envs[project_b.id]["newGroups"] == 2
-        assert release_data_both_envs["newGroups"] == 6
+        assert len(result) == 1
+        serialized_release = result[0]
+        projects = {p["id"]: p for p in serialized_release["projects"]}
+        assert projects[project_a.id]["newGroups"] == 4
+        assert projects[project_b.id]["newGroups"] == 2
+        assert serialized_release["newGroups"] == 6
 
-    def test_cross_project_release_environment_complex(self):
+    def test_new_groups_cross_project_release_environment(self):
         """
-        Test complex scenario: Multiple releases, projects, and environments.
-
-        Scenario:
-        - Release "1.0.0":
-          - Project A: 3 issues in production, 1 issue in staging
-          - Project B: 2 issues in production, 0 issues in staging
-        - Release "2.0.0":
-          - Project A: 1 issue in production, 2 issues in staging
-          - Project B: 4 issues in production, 1 issue in staging
-
-        When serializing Release "1.0.0" with production filter:
-        - Should return: Project A = 3, Project B = 2
-        - Should NOT include counts from Release "2.0.0"
+        Test new group counts for multiple releases with different environments.
         """
-        # TODO: Implement test
-        pass
+        project_a = self.create_project(name="Project A", slug="project-a")
+        project_b = self.create_project(
+            name="Project B", slug="project-b", organization=project_a.organization
+        )
+
+        production = self.create_environment(name="production", organization=project_a.organization)
+        staging = self.create_environment(name="staging", organization=project_a.organization)
+
+        release_1 = Release.objects.create(
+            organization_id=project_a.organization_id, version="1.0.0"
+        )
+        release_1.add_project(project_a)
+        release_1.add_project(project_b)
+
+        release_2 = Release.objects.create(
+            organization_id=project_a.organization_id, version="2.0.0"
+        )
+        release_2.add_project(project_a)
+        release_2.add_project(project_b)
+
+        # Release 1.0.0: Project A = 4 (3+1), Project B = 2 (2+0)
+        ReleaseProject.objects.filter(release=release_1, project=project_a).update(new_groups=4)
+        ReleaseProject.objects.filter(release=release_1, project=project_b).update(new_groups=2)
+        # Release 2.0.0: Project A = 3 (1+2), Project B = 5 (4+1)
+        ReleaseProject.objects.filter(release=release_2, project=project_a).update(new_groups=3)
+        ReleaseProject.objects.filter(release=release_2, project=project_b).update(new_groups=5)
+
+        # Release 1.0.0 - Project A: 3 in production, 1 in staging
+        ReleaseProjectEnvironment.objects.create(
+            release=release_1, project=project_a, environment=production, new_issues_count=3
+        )
+        ReleaseProjectEnvironment.objects.create(
+            release=release_1, project=project_a, environment=staging, new_issues_count=1
+        )
+        # Release 1.0.0 - Project B: 2 in production, 0 in staging (no staging record)
+        ReleaseProjectEnvironment.objects.create(
+            release=release_1, project=project_b, environment=production, new_issues_count=2
+        )
+        # Release 2.0.0 - Project A: 1 in production, 2 in staging
+        ReleaseProjectEnvironment.objects.create(
+            release=release_2, project=project_a, environment=production, new_issues_count=1
+        )
+        ReleaseProjectEnvironment.objects.create(
+            release=release_2, project=project_a, environment=staging, new_issues_count=2
+        )
+        # Release 2.0.0 - Project B: 4 in production, 1 in staging
+        ReleaseProjectEnvironment.objects.create(
+            release=release_2, project=project_b, environment=production, new_issues_count=4
+        )
+        ReleaseProjectEnvironment.objects.create(
+            release=release_2, project=project_b, environment=staging, new_issues_count=1
+        )
+
+        # 1. Serialize Release 1.0.0 with production filter
+        result = release_serializer(
+            releases=[release_1],
+            user=self.user,
+            organization_id=project_a.organization_id,
+            environment_ids=[production.id],
+            projects=[project_a, project_b],
+        )
+        assert len(result) == 1
+        serialized_release = result[0]
+        assert serialized_release["version"] == "1.0.0"
+        assert serialized_release["newGroups"] == 5
+        projects = {p["id"]: p for p in serialized_release["projects"]}
+        assert projects[project_a.id]["newGroups"] == 3
+        assert projects[project_b.id]["newGroups"] == 2
+
+        # 2. Serialize Release 2.0.0 with production filter
+        result = release_serializer(
+            releases=[release_2],
+            user=self.user,
+            organization_id=project_a.organization_id,
+            environment_ids=[production.id],
+            projects=[project_a, project_b],
+        )
+        assert len(result) == 1
+        serialized_release = result[0]
+        assert serialized_release["version"] == "2.0.0"
+        assert serialized_release["newGroups"] == 5
+        projects = {p["id"]: p for p in serialized_release["projects"]}
+        assert projects[project_a.id]["newGroups"] == 1
+        assert projects[project_b.id]["newGroups"] == 4
+
+        # 3. Serialize both releases together with production filter
+        result = release_serializer(
+            releases=[release_1, release_2],
+            user=self.user,
+            organization_id=project_a.organization_id,
+            environment_ids=[production.id],
+            projects=[project_a, project_b],
+        )
+        assert len(result) == 2
+        serialized_releases = {r["version"]: r for r in result}
+        serialized_release_1 = serialized_releases["1.0.0"]
+        serialized_release_2 = serialized_releases["2.0.0"]
+        assert serialized_release_1["newGroups"] == 5
+        assert serialized_release_2["newGroups"] == 5
+        projects_1 = {p["id"]: p for p in serialized_release_1["projects"]}
+        projects_2 = {p["id"]: p for p in serialized_release_2["projects"]}
+        assert projects_1[project_a.id]["newGroups"] == 3
+        assert projects_1[project_b.id]["newGroups"] == 2
+        assert projects_2[project_a.id]["newGroups"] == 1
+        assert projects_2[project_b.id]["newGroups"] == 4
+
+        # 5. Serialize Release 1.0.0 with no environment filter
+        result = release_serializer(
+            releases=[release_1],
+            user=self.user,
+            organization_id=project_a.organization_id,
+            environment_ids=[],
+            projects=[project_a, project_b],
+        )
+        assert len(result) == 1
+        serialized_release = result[0]
+        assert serialized_release["newGroups"] == 6
+        projects = {p["id"]: p for p in serialized_release["projects"]}
+        assert projects[project_a.id]["newGroups"] == 4
+        assert projects[project_b.id]["newGroups"] == 2

--- a/tests/sentry/releases/use_cases/test_release_serializer.py
+++ b/tests/sentry/releases/use_cases/test_release_serializer.py
@@ -178,6 +178,9 @@ class ReleaseSerializerUseCaseTest(TestCase):
         ReleaseProjectEnvironment.objects.create(
             release=release, project=project_b, environment=production, new_issues_count=2
         )
+        ReleaseProjectEnvironment.objects.create(
+            release=release, project=project_b, environment=staging, new_issues_count=0
+        )
 
         # 1. No environment filter
         result = release_serializer(
@@ -221,7 +224,7 @@ class ReleaseSerializerUseCaseTest(TestCase):
         serialized_release = result[0]
         projects = {p["id"]: p for p in serialized_release["projects"]}
         assert projects[project_a.id]["newGroups"] == 1
-        assert project_b.id not in projects
+        assert projects[project_b.id]["newGroups"] == 0
         assert serialized_release["newGroups"] == 1
 
         # 4. Filter by both environments


### PR DESCRIPTION
Originally, the number of new groups per project for a certain release was incorrect - it showed the same number for all projects in a release. This is because we were using the per-project new groups count (ie, release.projects[x].newGroups), which was incorrectly returning the sum of all new group counts across _all_ releases for that project. 

In https://github.com/getsentry/sentry/pull/99555 we switched to using release.newGroups. But this also incorrectly returns the total number of new issues across all projects for that release. 

Here we fix the underlying issue with release.projects[x].newGroups by setting it to the new groups count for that release in that project. This fix only applies to the _new_ serializer.

---
*Copied from getsentry/sentry#100919*
*Original PR: https://github.com/getsentry/sentry/pull/100919*