### PR TITLE
chore(eco): async deletions for sentry app installations 

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
@@ -230,7 +230,6 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                             SentryAppInstallationNotifier(
                                 sentry_app_installation=install, user=request.user, action="deleted"
                             ).run()
-                            ScheduledDeletion.schedule(install, days=0, actor=request.user)
                     except RequestException as exc:
                         sentry_sdk.capture_exception(exc)
 

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
@@ -8,7 +8,7 @@ from requests import RequestException
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, audit_log, deletions, features
+from sentry import analytics, audit_log, features
 from sentry.analytics.events.sentry_app_deleted import SentryAppDeletedEvent
 from sentry.analytics.events.sentry_app_schema_validation_error import (
     SentryAppSchemaValidationError,
@@ -230,7 +230,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
                             SentryAppInstallationNotifier(
                                 sentry_app_installation=install, user=request.user, action="deleted"
                             ).run()
-                            deletions.exec_sync(install)
+                            ScheduledDeletion.schedule(install, days=0, actor=request.user)
                     except RequestException as exc:
                         sentry_sdk.capture_exception(exc)
 


### PR DESCRIPTION
Deleting a sentry app installation should use async deletions.

The tests for async sentry app deletion cover the below case:
- Sentry app installations are already collected when we delete the sentry app so we shouldn't need to have extra deletions queued up / done before the task.

https://github.com/getsentry/sentry/blob/e49b651754eaad16f271ce8ddf7e97a457f64cf3/src/sentry/deletions/defaults/sentry_app.py#L14

Required for https://github.com/getsentry/sentry/pull/100813

---
*Copied from getsentry/sentry#100930*
*Original PR: https://github.com/getsentry/sentry/pull/100930*