### PR TITLE
fix(ui): cut-off feedback button in chonk

### DIFF
--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -69,7 +69,7 @@ export default function GroupingInfo({
   );
 
   return (
-    <GroupingInfoContainer>
+    <Fragment>
       <ConfigHeader>
         {hasStreamlinedUI && (
           <GroupInfoSummary
@@ -116,16 +116,9 @@ export default function GroupingInfo({
               </Fragment>
             ))
         : null}
-    </GroupingInfoContainer>
+    </Fragment>
   );
 }
-
-const GroupingInfoContainer = styled('div')`
-  width: 100%;
-  max-width: 100%;
-  overflow: hidden;
-  box-sizing: border-box;
-`;
 
 const ConfigHeader = styled('div')`
   display: flex;

--- a/static/app/components/events/groupingInfo/groupingSummary.tsx
+++ b/static/app/components/events/groupingInfo/groupingSummary.tsx
@@ -40,7 +40,13 @@ export function GroupInfoSummary({
       : null;
 
   if (isPending && !hasPerformanceGrouping) {
-    return <Placeholder height="20px" style={{marginBottom: '20px'}} />;
+    return (
+      <Placeholder
+        height="20px"
+        width="unset"
+        style={{flexGrow: 1, marginBottom: '20px'}}
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
Initially, we had an issue that the feedback button was displayed outside the container when we showing a placeholder:

<img width="1215" height="313" alt="Screenshot 2025-10-06 at 19 44 28" src="https://github.com/user-attachments/assets/05f2ba81-4241-4ae0-8e94-e8faddc9e638" />

There was an attempted fix by @shayna-ch here:

- https://github.com/getsentry/sentry/pull/98928

which seemed to work, however, it relies on `overflow:hidden`, which doesn’t work well in `chonk` because it cuts-off our buttons:

<img width="1198" height="313" alt="Screenshot 2025-10-06 at 19 44 01" src="https://github.com/user-attachments/assets/3187fb6b-a9d5-4b52-a19e-fb486e850379" />

What the fix tried to do was to limit the width of the container and force the content to not exceed its bounds with `overfow:hidden`.

However, the root cause seems to be that we are exceeding the bounds in the first place. Why is that?

It’s because the `Placeholder` component has a default width of `width:100%`, which is not what we want when there’s content next to it.
Luckily, we are in a `flex` layout, so what we really want to do is have the `<Placeholder>` use all the remaining width, which we can do with `flexGrow:1`.

I have therefore removed the `GroupingInfoContainer` that was introduced in #98928 and reverted back to a `Fragment` and fixed the issue by unsetting the `width` of the `Placeholder` and applying `flexGrow:1` to it instead.

<img width="1198" height="313" alt="Screenshot 2025-10-06 at 19 43 40" src="https://github.com/user-attachments/assets/a431c79f-2aa4-4b4f-bd2d-f37d1b1d1a63" />

Note: It’s weird that `Placeholder` has a default width of 100% - I don’t think we should be using `width:100%` in flex layouts, but I didn’t dare changing that inside `Placeholder` because it has so many usages.

---
*Copied from getsentry/sentry#100985*
*Original PR: https://github.com/getsentry/sentry/pull/100985*