### PR TITLE
fix(aci): Return empty list from open periods endpoint when detector has no linked group 

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_open_periods.py
+++ b/src/sentry/workflow_engine/endpoints/organization_open_periods.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from drf_spectacular.utils import OpenApiParameter, extend_schema
-from rest_framework import status
 from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -128,10 +127,8 @@ class OrganizationOpenPeriodsEndpoint(OrganizationEndpoint):
             )
         )
         if not target_group:
-            return Response(
-                {"detail": "Group not found. Could not query open periods."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+            return self.paginate(request=request, queryset=[])
+
         limit = None
         per_page = request.GET.get("per_page")
         if per_page:

--- a/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_open_periods.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 from django.utils import timezone
-from rest_framework import status
 
 from sentry.incidents.grouptype import MetricIssue
 from sentry.models.activity import Activity
@@ -52,12 +51,12 @@ class OrganizationOpenPeriodsTest(APITestCase):
     def test_no_group_link(self) -> None:
         # Create a new detector with no linked group
         detector = self.create_detector()
-        resp = self.get_error_response(
+        resp = self.get_success_response(
             self.organization.slug,
             qs_params={"detectorId": detector.id},
-            status_code=status.HTTP_404_NOT_FOUND,
+            status_code=200,
         )
-        assert resp.data["detail"] == "Group not found. Could not query open periods."
+        assert resp.data == []
 
     def test_open_period_linked_to_group(self) -> None:
         response = self.get_success_response(


### PR DESCRIPTION
This is an expected state, so IMO it should be a successful response with an empty list instead of a 404. This makes things simpler on the UI side.

---
*Copied from getsentry/sentry#101046*
*Original PR: https://github.com/getsentry/sentry/pull/101046*