### PR TITLE
ref(grouping): Use better descriptions in Grouping Info section

### DIFF
--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any
 
 from sentry.grouping.strategies.base import StrategyConfiguration
-from sentry.grouping.variants import BaseVariant
+from sentry.grouping.variants import BaseVariant, ComponentVariant, SaltedComponentVariant
 from sentry.models.project import Project
 from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.utils import metrics
@@ -61,6 +61,57 @@ def _check_for_mismatched_hashes(
             )
         else:
             metrics.incr("event_grouping_info.hash_match")
+
+
+def _get_new_description(variant: BaseVariant) -> str:
+    """
+    Get a human-readable description of the grouping method for use in the grouping info section of
+    the issue details page.
+
+    TODO: As a first step, we're replacing the description only in grouping info, at the last minute
+    before we return the API response. Once we switch to using key rather than description
+    elsewhere, this can replace the existing `description` logic.
+    """
+
+    description_by_key = {
+        "built_in_fingerprint": "Sentry-defined fingerprint",
+        "custom_fingerprint": "custom fingerprint",
+        "checksum": "checksum",
+        "csp_local_script_violation": "directive",
+        "csp_url": "directive and URL",
+        "expect_ct": "hostname",
+        "expect_staple": "hostname",
+        "fallback": "fallback grouping",
+        "hashed_checksum": "hashed checksum",
+        "hpkp": "hostname",
+        "template": "filename and context line",
+        "chained_exception_message": "chained error messages",
+        "chained_exception_type": "chained error types",
+        "exception_message": "error message",
+        "exception_type": "error type",
+        "message": "message",
+        "ns_error": "NSError",
+        "chained_exception_stacktrace": "chained exception stacktraces",
+        "exception_stacktrace": "exception stacktrace",
+        "stacktrace": "event-level stacktrace",
+        "thread_stacktrace": "thread stacktrace",
+    }
+    variant_name = variant.variant_name
+    # For component variants, we grab the key from the root component rather than the variant itself
+    # because that way we don't have to strip off variant name and (in the case of salted component
+    # variants) the hybrid fingerprint designation. (We handle both of those separately below.)
+    key = variant.root_component.key if isinstance(variant, ComponentVariant) else variant.key
+    grouping_method = description_by_key[key]
+
+    description_parts = [grouping_method]
+    if "stacktrace" in key and variant_name in ["app", "system"]:
+        stacktrace_descriptor = "— in-app frames" if variant_name == "app" else "— all frames"
+        description_parts.append(stacktrace_descriptor)
+
+    if isinstance(variant, SaltedComponentVariant):
+        description_parts.append("and custom fingerprint")
+
+    return " ".join(description_parts)
 
 
 def get_grouping_info_from_variants(

--- a/src/sentry/grouping/grouping_info.py
+++ b/src/sentry/grouping/grouping_info.py
@@ -129,4 +129,11 @@ def get_grouping_info_from_variants(
     if use_legacy_format:
         return {key: {"key": key, **variant.as_dict()} for key, variant in variants.items()}
 
-    return {variant.key: variant.as_dict() for variant in variants.values()}
+    return {
+        # Overwrite the description with a new, improved version
+        variant.key: {
+            **variant.as_dict(),
+            "description": _get_new_description(variant),
+        }
+        for variant in variants.values()
+    }

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/actix.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/actix.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.704248+00:00'
+created: '2025-10-06T21:57:32.649693+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -2605,7 +2605,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "738e7d2503464bc264b4f791286f5122",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -5212,7 +5212,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "19a96e0438d28e48355653def82f887a",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/android_anr.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.737894+00:00'
+created: '2025-10-06T21:57:32.675173+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -3934,7 +3934,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -7870,7 +7870,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "2552498cfe69a6ddf1dcdde5440ce9c3",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/aspnetcore.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/aspnetcore.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.759841+00:00'
+created: '2025-10-06T21:57:32.694439+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1093,7 +1093,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "228c649a3aa0901622c0a0e66ab0522c",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -1138,7 +1138,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "default",
+    "description": "message",
     "hash": null,
     "hint": "ignored because app/system exception takes precedence",
     "key": "message",
@@ -2233,7 +2233,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "4ccd0f1953483581ba360c7518f90332",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/block_invoke.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.777723+00:00'
+created: '2025-10-06T21:57:32.710788+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -143,7 +143,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app thread stacktrace",
+    "description": "thread stacktrace — in-app frames",
     "hash": "ff6c4ee7c54f118a9647ee86f0c2b0b0",
     "hint": null,
     "key": "app_thread_stacktrace",
@@ -188,7 +188,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "default",
+    "description": "message",
     "hash": null,
     "hint": "ignored because app threads take precedence",
     "key": "message",
@@ -333,7 +333,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "thread stacktrace — all frames",
     "hash": null,
     "hint": "ignored because app threads take precedence",
     "key": "system_thread_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/bugly.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/bugly.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.796412+00:00'
+created: '2025-10-06T21:57:32.728047+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -306,7 +306,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -614,7 +614,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "d9c9b0f9ba46e32fddd7cd1512fad235",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.833830+00:00'
+created: '2025-10-06T21:57:32.782637+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because built-in fingerprint takes precedence",
     "key": "app_exception_message",
@@ -111,7 +111,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   },
   "built_in_fingerprint": {
     "contributes": true,
-    "description": "Sentry defined fingerprint",
+    "description": "Sentry-defined fingerprint",
     "hash": "5d731dcf8ecc4f042eeacf528d8d8da9",
     "hint": null,
     "key": "built_in_fingerprint",
@@ -220,7 +220,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": null,
     "hint": "ignored because built-in fingerprint takes precedence",
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/built_in_fingerprint_chunkload_error_hybrid_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.815912+00:00'
+created: '2025-10-06T21:57:32.762297+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -103,7 +103,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because built-in fingerprint takes precedence",
     "key": "app_exception_message",
@@ -115,7 +115,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       "dogs are great"
     ],
     "contributes": true,
-    "description": "Sentry defined fingerprint",
+    "description": "Sentry-defined fingerprint",
     "hash": "5d731dcf8ecc4f042eeacf528d8d8da9",
     "hint": null,
     "key": "built_in_fingerprint",
@@ -224,7 +224,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": null,
     "hint": "ignored because built-in fingerprint takes precedence",
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/callee_guaranteed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.853310+00:00'
+created: '2025-10-06T21:57:32.804736+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1071,7 +1071,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "4ef1fb44d656c3be2a146971f2a222dc",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -2144,7 +2144,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "47481871aa8d5ab5729cf2db78ce3032",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/checksum_no_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/checksum_no_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T16:56:42.876169+00:00'
+created: '2025-10-06T19:13:32.140180+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "hashed_checksum": {
     "checksum": "de46d023e69b171b90ccf3ebca7aede4",
     "contributes": true,
-    "description": "hashed legacy checksum",
+    "description": "hashed checksum",
     "hash": "de46d023e69b171b90ccf3ebca7aede4",
     "hint": null,
     "key": "hashed_checksum",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/checksum_regex_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/checksum_regex_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T16:56:42.891907+00:00'
+created: '2025-10-06T19:13:32.155691+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -7,7 +7,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   "checksum": {
     "checksum": "11212012123120120415201309082013",
     "contributes": true,
-    "description": "legacy checksum",
+    "description": "checksum",
     "hash": "11212012123120120415201309082013",
     "hint": null,
     "key": "checksum",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/cocoa_dispatch_client_callout.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.905507+00:00'
+created: '2025-10-06T21:57:32.857244+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -515,7 +515,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app thread stacktrace",
+    "description": "thread stacktrace — in-app frames",
     "hash": "7c8a196d16b94be382add324be2605ee",
     "hint": null,
     "key": "app_thread_stacktrace",
@@ -560,7 +560,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "default",
+    "description": "message",
     "hash": null,
     "hint": "ignored because app/system threads take precedence",
     "key": "message",
@@ -1077,7 +1077,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "thread stacktrace",
+    "description": "thread stacktrace — all frames",
     "hash": "cd7f51d716fd57adc1a5ce1c112e538f",
     "hint": null,
     "key": "system_thread_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/connection_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.925132+00:00'
+created: '2025-10-06T21:57:32.877288+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -552,7 +552,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "6b059b9febc815ac18ac4d2082e38a9b",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -597,7 +597,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "default",
+    "description": "message",
     "hash": null,
     "hint": "ignored because app/system exception takes precedence",
     "key": "message",
@@ -1151,7 +1151,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "013d3477a774fe20c468dc8accd516f1",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_and_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.943139+00:00'
+created: '2025-10-06T21:57:32.894796+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -236,7 +236,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "161ce02ecc5d6685a72e8e520ab726b3",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -474,7 +474,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "c5e4b4a9ad1803c4d4ca7feee5e430ae",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/contributing_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.962008+00:00'
+created: '2025-10-06T21:57:32.911645+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -194,7 +194,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -390,7 +390,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "fe92cff6711f8a0a30cabb8b9245b1d6",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.100616+00:00'
+created: '2025-10-06T19:13:32.350248+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,7 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "URL",
+    "description": "directive and URL",
     "hash": "666766514295bb52812324097cdaf53e",
     "hint": null,
     "key": "csp_url",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_img_src.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_img_src.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.978411+00:00'
+created: '2025-10-06T19:13:32.239217+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "URL",
+    "description": "directive and URL",
     "hash": "1742101e08eb1608f569751dfedd0062",
     "hint": null,
     "key": "csp_url",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_no_blocked_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:44.994848+00:00'
+created: '2025-10-06T19:13:32.254483+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "URL",
+    "description": "directive and URL",
     "hash": "efddf1cde918097259aa7d4904fb1942",
     "hint": null,
     "key": "csp_url",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_data_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_data_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.011120+00:00'
+created: '2025-10-06T19:13:32.272101+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "URL",
+    "description": "directive and URL",
     "hash": "4e6f2bce9d121aa89f4dc5e5da08afb5",
     "hint": null,
     "key": "csp_url",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_eval.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.027385+00:00'
+created: '2025-10-06T19:13:32.289018+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -78,7 +78,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "violation",
+    "description": "directive",
     "hash": "56c6520f35bce2f89ed2c4e725ccef65",
     "hint": null,
     "key": "csp_local_script_violation",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_unsafe_inline.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.042995+00:00'
+created: '2025-10-06T19:13:32.305823+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -78,7 +78,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "violation",
+    "description": "directive",
     "hash": "d346ee37d19a2be6587e609075ca2d57",
     "hint": null,
     "key": "csp_local_script_violation",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_uri.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_script_src_uri.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.061647+00:00'
+created: '2025-10-06T19:13:32.320608+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "URL",
+    "description": "directive and URL",
     "hash": "223cdacfe5b4b830dc700b5c18cc21b4",
     "hint": null,
     "key": "csp_url",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_style_src_elem.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/csp_style_src_elem.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.081641+00:00'
+created: '2025-10-06T19:13:32.335868+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -76,7 +76,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "URL",
+    "description": "directive and URL",
     "hash": "537a973f594c364842893e9a72af62a5",
     "hint": null,
     "key": "csp_url",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.139451+00:00'
+created: '2025-10-06T21:57:33.068626+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -816,7 +816,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because custom client fingerprint takes precedence",
     "key": "app_exception_stacktrace",
@@ -1652,7 +1652,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": null,
     "hint": "ignored because custom client fingerprint takes precedence",
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_client_and_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.119473+00:00'
+created: '2025-10-06T21:57:33.051565+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -816,7 +816,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because custom server fingerprint takes precedence",
     "key": "app_exception_stacktrace",
@@ -1651,7 +1651,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": null,
     "hint": "ignored because custom server fingerprint takes precedence",
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/custom_fingerprint_server_rule.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.160747+00:00'
+created: '2025-10-06T21:57:33.086075+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -816,7 +816,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because custom server fingerprint takes precedence",
     "key": "app_exception_stacktrace",
@@ -1646,7 +1646,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": null,
     "hint": "ignored because custom server fingerprint takes precedence",
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/empty.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/empty.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2025-10-03T16:56:43.337650+00:00'
+created: '2025-10-06T21:57:33.102394+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
 {
   "fallback": {
     "contributes": true,
-    "description": "fallback",
+    "description": "fallback grouping",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
     "hint": null,
     "key": "fallback",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.199295+00:00'
+created: '2025-10-06T21:57:33.120005+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -822,7 +822,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "NSError",
     "hash": "029f3b967068b1539f96957b7c0451d7",
     "hint": null,
     "key": "app_ns_error",
@@ -1587,7 +1587,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "thread stacktrace — all frames",
     "hash": null,
     "hint": "ignored because app exception takes precedence",
     "key": "system_thread_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.252631+00:00'
+created: '2025-10-06T19:13:32.481569+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error message",
     "hash": "b23ee1963904c2ca87b145febf94b66c",
     "hint": null,
     "key": "app_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.217444+00:00'
+created: '2025-10-06T21:57:33.135836+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -99,7 +99,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "9509e122c6175606d52862fa4f64853c",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -200,7 +200,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "exception stacktrace — all frames",
     "hash": null,
     "hint": "ignored because app exception takes precedence",
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.236099+00:00'
+created: '2025-10-06T21:57:33.151299+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -172,7 +172,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "chained exception stacktraces — in-app frames",
     "hash": "669cb6664e0f5fed38665da04e464f7e",
     "hint": null,
     "key": "app_chained_exception_stacktrace",
@@ -346,7 +346,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "chained exception stacktraces — all frames",
     "hash": null,
     "hint": "ignored because app exception takes precedence",
     "key": "system_chained_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.272452+00:00'
+created: '2025-10-06T19:13:32.497074+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -141,7 +141,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "chained error messages",
     "hash": "e2bf1e0628b7b1824a9b63dec7a079a3",
     "hint": null,
     "key": "app_chained_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.310666+00:00'
+created: '2025-10-06T19:13:32.528565+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -108,7 +108,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "chained error messages",
     "hash": "93b26686d00504b4e5aa1cb0244d8b37",
     "hint": null,
     "key": "app_chained_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_inner_self_parenting_duplicate_id.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.291570+00:00'
+created: '2025-10-06T19:13:32.512717+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -108,7 +108,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "chained error messages",
     "hash": "93b26686d00504b4e5aa1cb0244d8b37",
     "hint": null,
     "key": "app_chained_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_missing_parent.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.330674+00:00'
+created: '2025-10-06T19:13:32.543716+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error message",
     "hash": "a4f16891fa438620699cb2d9af5cc827",
     "hint": null,
     "key": "app_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_no_root.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.350137+00:00'
+created: '2025-10-06T19:13:32.559194+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -108,7 +108,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "chained error messages",
     "hash": "028157fe357e4592e39eacb32eafa2db",
     "hint": null,
     "key": "app_chained_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_out_of_sequence.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.449245+00:00'
+created: '2025-10-06T19:13:32.574671+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -108,7 +108,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "chained error messages",
     "hash": "f0078a82f351095ba595daa7d493aa3c",
     "hint": null,
     "key": "app_chained_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_root_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.475884+00:00'
+created: '2025-10-06T19:13:32.592338+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -108,7 +108,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "chained error messages",
     "hash": "93b26686d00504b4e5aa1cb0244d8b37",
     "hint": null,
     "key": "app_chained_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_solo_self_parenting.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.503250+00:00'
+created: '2025-10-06T19:13:32.609557+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error message",
     "hash": "0809098f9f613b63467605dd1739cc9b",
     "hint": null,
     "key": "app_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_bad_with_cycle.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.521457+00:00'
+created: '2025-10-06T19:13:32.625070+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error message",
     "hash": "0809098f9f613b63467605dd1739cc9b",
     "hint": null,
     "key": "app_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_exception.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_exception.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.540062+00:00'
+created: '2025-10-06T19:13:32.640762+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error message",
     "hash": "a4f16891fa438620699cb2d9af5cc827",
     "hint": null,
     "key": "app_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_under_nested_groups.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.557156+00:00'
+created: '2025-10-06T19:13:32.657794+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error message",
     "hash": "a4f16891fa438620699cb2d9af5cc827",
     "hint": null,
     "key": "app_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_different_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.574940+00:00'
+created: '2025-10-06T19:13:32.673352+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -141,7 +141,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "chained error messages",
     "hash": "17022e0561e9b6e6351723a08aa81b18",
     "hint": null,
     "key": "app_chained_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.610554+00:00'
+created: '2025-10-06T19:13:32.709499+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error message",
     "hash": "a4f16891fa438620699cb2d9af5cc827",
     "hint": null,
     "key": "app_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_one_type_with_similar_values_and_children.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.593305+00:00'
+created: '2025-10-06T19:13:32.690686+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -108,7 +108,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "chained error messages",
     "hash": "f0078a82f351095ba595daa7d493aa3c",
     "hint": null,
     "key": "app_chained_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_exceptions_with_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.629306+00:00'
+created: '2025-10-06T21:57:33.398579+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -275,7 +275,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "chained exception stacktraces — in-app frames",
     "hash": "d505dfb9059ac63c11955233323a9100",
     "hint": null,
     "key": "app_chained_exception_stacktrace",
@@ -519,7 +519,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "chained exception stacktraces — all frames",
     "hash": "4f9cc6a81f4eb34f9e917374f281b9dc",
     "hint": null,
     "key": "system_chained_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.665039+00:00'
+created: '2025-10-06T19:13:32.761299+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -141,7 +141,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "chained error messages",
     "hash": "bca604b98cb4637167eb6190a92e8933",
     "hint": null,
     "key": "app_chained_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_groups_two_types_under_nested_groups.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.647578+00:00'
+created: '2025-10-06T19:13:32.742860+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -141,7 +141,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "chained error messages",
     "hash": "fca0fd23f09e8da4481304ef2a531100",
     "hint": null,
     "key": "app_chained_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_javascript_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.684362+00:00'
+created: '2025-10-06T21:57:33.445062+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -154,7 +154,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -310,7 +310,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "26552f86ca2368e708afa1df6effc1c5",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_type.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_type.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.700932+00:00'
+created: '2025-10-06T19:13:32.801470+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -65,7 +65,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error message",
     "hash": "5eb63bbbe01eeed093cb22bb8f5acdc3",
     "hint": null,
     "key": "app_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_value.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/exception_without_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.717368+00:00'
+created: '2025-10-06T19:13:32.820446+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -65,7 +65,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error type",
     "hash": "5a2cfd89b7b171fd7b4794b08023d04f",
     "hint": null,
     "key": "app_exception_type",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/fallback_prefix_level_1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.835081+00:00'
+created: '2025-10-06T21:57:33.581490+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -252,7 +252,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error type",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_type",
@@ -506,7 +506,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "87497299851e09febfecf4e84e0d45ba",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_compute_hashes_ignores_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.852069+00:00'
+created: '2025-10-06T21:57:33.597610+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "526b64456c48836a46ec1a89544fd412",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_empty_list.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_empty_list.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.870471+00:00'
+created: '2025-10-06T21:57:33.614884+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -41,7 +41,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": null,
     "key": "app_stacktrace",
@@ -49,7 +49,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   },
   "fallback": {
     "contributes": true,
-    "description": "fallback",
+    "description": "fallback grouping",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
     "hint": null,
     "key": "fallback",
@@ -92,7 +92,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "event-level stacktrace — all frames",
     "hash": null,
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.887991+00:00'
+created: '2025-10-06T21:57:33.631396+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "7d2cc7acbf90328200d960bf78a26234",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_fast_class_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.905631+00:00'
+created: '2025-10-06T21:57:33.647502+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "465d672b2d322bf6a1b44499f6dabc1f",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.923981+00:00'
+created: '2025-10-06T21:57:33.664398+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "45c0b0a8c777e7a7040d7c39233a08a5",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_dartlang_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.940808+00:00'
+created: '2025-10-06T21:57:33.680026+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": null,
     "key": "app_stacktrace",
@@ -83,7 +83,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   },
   "fallback": {
     "contributes": true,
-    "description": "fallback",
+    "description": "fallback grouping",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
     "hint": null,
     "key": "fallback",
@@ -160,7 +160,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "event-level stacktrace — all frames",
     "hash": null,
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_clojure_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.959722+00:00'
+created: '2025-10-06T21:57:33.700186+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "353e05904b48bd3ae4fa9623934a70d0",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_enhancer_by_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.977408+00:00'
+created: '2025-10-06T21:57:33.715737+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "0094f39fc617031afb6c655419f4a9f2",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_extra_ENHANCED_spring_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:45.995582+00:00'
+created: '2025-10-06T21:57:33.731351+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "be15ca3d511b96918e087c4f42503ca2",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_from_url_origin_corner_cases.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.012840+00:00'
+created: '2025-10-06T21:57:33.746631+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -166,7 +166,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -334,7 +334,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "e04dce7550635e05dbd7f656102cf304",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_abs_path_is_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.029330+00:00'
+created: '2025-10-06T21:57:33.764891+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "098f6bcd4621d373cade4e832627b4f6",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_blob.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.044864+00:00'
+created: '2025-10-06T21:57:33.780251+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -73,7 +73,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": null,
     "key": "app_stacktrace",
@@ -81,7 +81,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   },
   "fallback": {
     "contributes": true,
-    "description": "fallback",
+    "description": "fallback grouping",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
     "hint": null,
     "key": "fallback",
@@ -156,7 +156,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "event-level stacktrace — all frames",
     "hash": null,
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_http.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.061837+00:00'
+created: '2025-10-06T21:57:33.795682+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -170,7 +170,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "64a0e0a34d99dce03a8c5a4c237a4b5a",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_filename_if_https.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.077728+00:00'
+created: '2025-10-06T21:57:33.814602+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -170,7 +170,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "64a0e0a34d99dce03a8c5a4c237a4b5a",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.094498+00:00'
+created: '2025-10-06T21:57:33.830301+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -77,7 +77,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -156,7 +156,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "e0e7c4713e9092dc77635d5a0d5db31d",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_hibernate_classes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.110767+00:00'
+created: '2025-10-06T21:57:33.844846+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "c32a94349d9e9b72d31a46610c6c9589",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.131451+00:00'
+created: '2025-10-06T21:57:33.859996+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "be7f1b8b4014de623c533a8218dba5bd",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_java8_lambda_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.153641+00:00'
+created: '2025-10-06T21:57:33.875193+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "53b9e9679a8ea25880376080b76f98ad",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.207800+00:00'
+created: '2025-10-06T21:57:33.921372+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "538bdfd8d7bb2495d0d6429c3689a420",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.173004+00:00'
+created: '2025-10-06T21:57:33.890768+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "538bdfd8d7bb2495d0d6429c3689a420",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_javassist_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.190550+00:00'
+created: '2025-10-06T21:57:33.905831+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "dc3d511120ce04996b1eef3496516e5c",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.241128+00:00'
+created: '2025-10-06T21:57:33.952966+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": null,
     "key": "app_stacktrace",
@@ -83,7 +83,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   },
   "fallback": {
     "contributes": true,
-    "description": "fallback",
+    "description": "fallback grouping",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
     "hint": null,
     "key": "fallback",
@@ -160,7 +160,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "event-level stacktrace — all frames",
     "hash": null,
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_module_if_page_url_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.224427+00:00'
+created: '2025-10-06T21:57:33.935442+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -77,7 +77,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -156,7 +156,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "0cc175b9c0f1b6a831c399e269772661",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_safari_native_code.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.257738+00:00'
+created: '2025-10-06T21:57:33.970701+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "30eb5001914d29dd8461898b5b8094fe",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_packages.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.274615+00:00'
+created: '2025-10-06T21:57:33.990298+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -273,7 +273,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": null,
     "key": "app_stacktrace",
@@ -281,7 +281,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   },
   "fallback": {
     "contributes": true,
-    "description": "fallback",
+    "description": "fallback grouping",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
     "hint": null,
     "key": "fallback",
@@ -556,7 +556,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "event-level stacktrace — all frames",
     "hash": null,
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_dart_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.290367+00:00'
+created: '2025-10-06T21:57:34.006146+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": null,
     "key": "app_stacktrace",
@@ -83,7 +83,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   },
   "fallback": {
     "contributes": true,
-    "description": "fallback",
+    "description": "fallback grouping",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
     "hint": null,
     "key": "fallback",
@@ -160,7 +160,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "event-level stacktrace — all frames",
     "hash": null,
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sentry_flutter_sdk.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.306522+00:00'
+created: '2025-10-06T21:57:34.022570+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": null,
     "key": "app_stacktrace",
@@ -83,7 +83,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   },
   "fallback": {
     "contributes": true,
-    "description": "fallback",
+    "description": "fallback grouping",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
     "hint": null,
     "key": "fallback",
@@ -160,7 +160,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "event-level stacktrace — all frames",
     "hash": null,
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.341412+00:00'
+created: '2025-10-06T21:57:34.056159+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "07d1a8e5728b3c4c7aa8b8273fd0e753",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_constructors_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.323178+00:00'
+created: '2025-10-06T21:57:34.039065+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "09e0efcab18f545166318118ed4e0292",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_ignores_sun_java_generated_methods.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.360418+00:00'
+created: '2025-10-06T21:57:34.071573+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -108,7 +108,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -218,7 +218,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "9bc326575875422d0d4ced3c35d9f916",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_block_functions.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.379336+00:00'
+created: '2025-10-06T21:57:34.086671+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "27eed4125fc13d42163ddb0b8f357b48",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_erb_templates.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.397915+00:00'
+created: '2025-10-06T21:57:34.102173+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "4067a71d7098866f87c746a57a77b2bb",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.433177+00:00'
+created: '2025-10-06T21:57:34.133776+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -73,7 +73,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -148,7 +148,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "2f908c015ad77a50595512fcf65d344c",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_sanitizes_versioned_filenames_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.415613+00:00'
+created: '2025-10-06T21:57:34.118292+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -73,7 +73,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -148,7 +148,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "2f908c015ad77a50595512fcf65d344c",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_context_line_over_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.450433+00:00'
+created: '2025-10-06T21:57:34.148726+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -84,7 +84,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -170,7 +170,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "60e0a667027bef0d0b7c4882891df7e8",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_uses_module_over_filename.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.469339+00:00'
+created: '2025-10-06T21:57:34.164023+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "acbd18db4cc2f85cedef654fccc4a4d8",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/frame_with_only_required_vars.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.488303+00:00'
+created: '2025-10-06T21:57:34.179295+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -73,7 +73,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -148,7 +148,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "1effb24729ae4c43efa36b460511136a",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/go_pkg_mod.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.507237+00:00'
+created: '2025-10-06T21:57:34.194424+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -138,7 +138,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "4b8bbc500bd2cabfcadc1f1be867e0bb",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -278,7 +278,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "348fc4026c9fa11ffba8fbfa80a134c9",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_125_event_126.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.529274+00:00'
+created: '2025-10-06T21:57:34.212719+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1260,7 +1260,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -2522,7 +2522,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "3da34e8c72dbcd4a490ac36eb7130638",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_200_event_200.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.581498+00:00'
+created: '2025-10-06T21:57:34.230469+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -812,7 +812,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -1626,7 +1626,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "ca733a48a19d237df8577d09449095d9",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_275_event_275.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.623757+00:00'
+created: '2025-10-06T21:57:34.247929+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -940,7 +940,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -1882,7 +1882,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "2c1bbd635b64d5adccdb64a620044075",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_289_event_312.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.648056+00:00'
+created: '2025-10-06T21:57:34.265868+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -820,7 +820,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -1642,7 +1642,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "9c336f632f6764c0f082a6a66edbf22d",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_294.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.675241+00:00'
+created: '2025-10-06T21:57:34.283845+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1289,7 +1289,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -2580,7 +2580,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "49b6f72b6635cb43190c57ee56b026b0",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_294_event_329.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.697976+00:00'
+created: '2025-10-06T21:57:34.302685+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1332,7 +1332,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -2666,7 +2666,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "49b6f72b6635cb43190c57ee56b026b0",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_307.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.717605+00:00'
+created: '2025-10-06T21:57:34.320433+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -564,7 +564,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -1130,7 +1130,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "aeed765d29d1a60cb094f66d2cd8efb2",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_307_event_657.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.738513+00:00'
+created: '2025-10-06T21:57:34.336512+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -587,7 +587,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -1176,7 +1176,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "aeed765d29d1a60cb094f66d2cd8efb2",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_313.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.761750+00:00'
+created: '2025-10-06T21:57:34.356494+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1897,7 +1897,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -3796,7 +3796,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "8be5979a334287a1b47457228f1d4612",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_313_event_333.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.787548+00:00'
+created: '2025-10-06T21:57:34.377905+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1818,7 +1818,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -3638,7 +3638,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "8be5979a334287a1b47457228f1d4612",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_319_event_321.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.814398+00:00'
+created: '2025-10-06T21:57:34.400498+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1928,7 +1928,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -3858,7 +3858,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "7e64037e487c78ce0439f750a2ef503f",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_389_event_389.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.834614+00:00'
+created: '2025-10-06T21:57:34.417749+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -378,7 +378,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -758,7 +758,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "aeed765d29d1a60cb094f66d2cd8efb2",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_432.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.855632+00:00'
+created: '2025-10-06T21:57:34.435872+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1134,7 +1134,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -2270,7 +2270,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "6148c73af04344a8597354711f5951ea",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_432_event_453.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.875658+00:00'
+created: '2025-10-06T21:57:34.454185+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1134,7 +1134,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -2270,7 +2270,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "1056f62d72ff8b4d0c3842d696dbb10a",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/group_445_event_445.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.897637+00:00'
+created: '2025-10-06T21:57:34.472211+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1239,7 +1239,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -2480,7 +2480,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "15526a7b64e9b5dc6d89e7ebec864260",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.934350+00:00'
+created: '2025-10-06T21:57:34.504277+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -71,7 +71,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "modified in-app exception",
+    "description": "error message and custom fingerprint",
     "hash": "e3d593b4335190212ca7c18b8e967fb1",
     "hint": null,
     "key": "app_exception_message_hybrid_fingerprint",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_custom_client_hybrid_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.955788+00:00'
+created: '2025-10-06T21:57:34.521625+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -821,7 +821,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "modified in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames and custom fingerprint",
     "hash": "19163f3ca34f5995c69d85351ce3d697",
     "hint": null,
     "key": "app_exception_stacktrace_hybrid_fingerprint",
@@ -1649,7 +1649,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "modified exception stacktrace",
+    "description": "exception stacktrace — all frames and custom fingerprint",
     "hash": "847950eb44d280e6758d136c763d6ddc",
     "hint": null,
     "key": "system_exception_stacktrace_hybrid_fingerprint",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_hybrid_client_custom_server.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.978236+00:00'
+created: '2025-10-06T21:57:34.538786+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -816,7 +816,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because custom server fingerprint takes precedence",
     "key": "app_exception_stacktrace",
@@ -1651,7 +1651,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": null,
     "hint": "ignored because custom server fingerprint takes precedence",
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_default_different_extra.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:46.996706+00:00'
+created: '2025-10-06T21:57:34.553731+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -71,7 +71,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "modified in-app exception",
+    "description": "error message and custom fingerprint",
     "hash": "5b5ad5a0fbb4deb5e3fc631ce42681ae",
     "hint": null,
     "key": "app_exception_message_hybrid_fingerprint",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/hybrid_fingerprint_same_extra_different_default.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.016148+00:00'
+created: '2025-10-06T21:57:34.569673+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -71,7 +71,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "modified in-app exception",
+    "description": "error message and custom fingerprint",
     "hash": "c5578778212497f1ff3435405e2a4a98",
     "hint": null,
     "key": "app_exception_message_hybrid_fingerprint",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/in_app_in_ui.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/in_app_in_ui.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.040499+00:00'
+created: '2025-10-06T21:57:34.588525+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1154,7 +1154,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "5b032559156688c9eabe4e4bd5ae6bd4",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -2310,7 +2310,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "1921b991270e24c19ea1ed6863892d71",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_chained.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.064582+00:00'
+created: '2025-10-06T21:57:34.607898+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1964,7 +1964,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "chained error messages",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_chained_exception_message",
@@ -2009,7 +2009,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "default",
+    "description": "message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "message",
@@ -3975,7 +3975,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "chained exception stacktraces — all frames",
     "hash": "1959b227a7cf6acf7f3fd401b5d9f09b",
     "hint": null,
     "key": "system_chained_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/java_minimal.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.087282+00:00'
+created: '2025-10-06T21:57:34.628122+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1993,7 +1993,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -2038,7 +2038,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "default",
+    "description": "message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "message",
@@ -4033,7 +4033,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "ef2555bf7958ada8eefafbfdaed1c409",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.123667+00:00'
+created: '2025-10-06T19:13:34.041571+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error message",
     "hash": "10dfd81e2df31e96fae451b9e205ad81",
     "hint": null,
     "key": "app_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_fallback_to_message_whistles.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.105616+00:00'
+created: '2025-10-06T19:13:34.026307+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error message",
     "hash": "b8e2a347e75266ca7bb565e2b3c0722e",
     "hint": null,
     "key": "app_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_exception_no_in_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.143373+00:00'
+created: '2025-10-06T21:57:34.675511+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -464,7 +464,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -930,7 +930,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "c0f3f7d6deb17aec9d07259ac684fad0",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_polyfills.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.199675+00:00'
+created: '2025-10-06T19:13:34.102704+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -167,7 +167,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error message",
     "hash": "be36642f41f047346396f018f62375d3",
     "hint": null,
     "key": "app_exception_message",
@@ -336,7 +336,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because app exception takes precedence",
     "key": "system_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_unpkg.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.218408+00:00'
+created: '2025-10-06T21:57:34.736670+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -202,7 +202,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -406,7 +406,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "6ab78545e13144405fb21dadb9045b91",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.238807+00:00'
+created: '2025-10-06T21:57:34.752854+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -394,7 +394,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -790,7 +790,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "c63e8727af1a8fe75872b6a762797113",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.263237+00:00'
+created: '2025-10-06T21:57:34.768272+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -398,7 +398,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -798,7 +798,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "c63e8727af1a8fe75872b6a762797113",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.282632+00:00'
+created: '2025-10-06T21:57:34.785463+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -363,7 +363,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -728,7 +728,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "c63e8727af1a8fe75872b6a762797113",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_chrome.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.303349+00:00'
+created: '2025-10-06T21:57:34.801874+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -412,7 +412,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -826,7 +826,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "b2602ad455472dede8e4c340d8a7eaba",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_edge.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.322775+00:00'
+created: '2025-10-06T21:57:34.818536+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -416,7 +416,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -834,7 +834,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "b2602ad455472dede8e4c340d8a7eaba",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.341555+00:00'
+created: '2025-10-06T21:57:34.835535+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -381,7 +381,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -764,7 +764,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "b2602ad455472dede8e4c340d8a7eaba",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_http_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.361057+00:00'
+created: '2025-10-06T21:57:34.852294+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -443,7 +443,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -888,7 +888,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "b2602ad455472dede8e4c340d8a7eaba",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.379711+00:00'
+created: '2025-10-06T21:57:34.868575+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -427,7 +427,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -856,7 +856,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "c63e8727af1a8fe75872b6a762797113",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_firefox.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.401270+00:00'
+created: '2025-10-06T21:57:34.886867+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -860,7 +860,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "4a3cf3893b6485428dd02da116c8370e",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -1722,7 +1722,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "d5456487ea8dccfe96c1968b19870978",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/javascript_xbrowser_sentryui_safari.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.421838+00:00'
+created: '2025-10-06T21:57:34.904704+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -717,7 +717,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "4a3cf3893b6485428dd02da116c8370e",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -1436,7 +1436,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "0b81da6ea3d7cc82b1d4825b7aac0b8d",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.464934+00:00'
+created: '2025-10-06T21:57:34.941441+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -2166,7 +2166,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "4665d486184740231357ab63f4543a8d",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -4334,7 +4334,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "107ed03036d901157372f260bc3df446",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel_anonymous.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/laravel_anonymous.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.441228+00:00'
+created: '2025-10-06T21:57:34.920860+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -192,7 +192,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "a728cdf5d62c8e017c35c3fe04051b6e",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -386,7 +386,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "63c67781779781d9b0a442a5b2bdb976",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_amd_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.531626+00:00'
+created: '2025-10-06T21:57:34.990467+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1583,7 +1583,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -3168,7 +3168,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "b8baf791d22ac902d5f59a7eedd844fd",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/macos_intel_driver.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.553987+00:00'
+created: '2025-10-06T21:57:35.011350+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1947,7 +1947,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -3896,7 +3896,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "36be6e0b6123ef6ecfbef62f5cb88406",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/malloc_sentinel.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.577449+00:00'
+created: '2025-10-06T21:57:35.029006+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -824,7 +824,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -1650,7 +1650,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "70b7b816193e06eb5d6649989fbaf605",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/minified_javascript.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.665674+00:00'
+created: '2025-10-06T21:57:35.099488+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1034,7 +1034,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error type",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_type",
@@ -2070,7 +2070,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "dcfcd48a02c100bbe4023cbc783054f0",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_complex_function_names.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.684049+00:00'
+created: '2025-10-06T21:57:35.116115+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -161,7 +161,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -324,7 +324,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "9b78cced1eefcd0c655a0a3d8ce2cdd2",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash1.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.703463+00:00'
+created: '2025-10-06T21:57:35.134286+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -283,7 +283,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -568,7 +568,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "2e0d26cae5986fcda5edf66612a78268",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.723235+00:00'
+created: '2025-10-06T21:57:35.152015+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -250,7 +250,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -502,7 +502,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "c85e23e804b52ea4b9f290ba838e77a0",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_driver_crash3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.741115+00:00'
+created: '2025-10-06T21:57:35.168595+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -312,7 +312,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -626,7 +626,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "784442a33bd16c15013bb8f69f68e7d6",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_limit_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.758998+00:00'
+created: '2025-10-06T21:57:35.186867+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -161,7 +161,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -324,7 +324,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "8f4c7709e4af98d3c47ce3519690e6d9",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_malloc_chain.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.777846+00:00'
+created: '2025-10-06T21:57:35.204951+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -254,7 +254,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -510,7 +510,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "3ff01ce959249abecc6bc8a8f1432b0b",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_no_filenames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_no_filenames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.796457+00:00'
+created: '2025-10-06T21:57:35.222394+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -502,7 +502,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "418120a66f7031923031f5c52aca0724",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -1006,7 +1006,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "bbcdb2e1d8df09ffe0fffd30fb361d4b",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_unlimited_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.817462+00:00'
+created: '2025-10-06T21:57:35.238778+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -161,7 +161,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -324,7 +324,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "9b78cced1eefcd0c655a0a3d8ce2cdd2",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_windows_anon_namespace.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.835877+00:00'
+created: '2025-10-06T21:57:35.255945+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -233,7 +233,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -468,7 +468,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "46b84e4da51648cc9f9741abd2bdad51",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.856607+00:00'
+created: '2025-10-06T21:57:35.272192+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -207,7 +207,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -409,7 +409,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "c29439027eafcf7642f641554ab0f0ef",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_exception_weird.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.875575+00:00'
+created: '2025-10-06T21:57:35.288915+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -490,7 +490,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "a20509269752c9a1bea6078851e4d39c",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -982,7 +982,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "252dc79eb5653bf822e2684d90734cb8",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/node_low_level_async.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.894535+00:00'
+created: '2025-10-06T19:13:34.669876+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -136,7 +136,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error message",
     "hash": "be36642f41f047346396f018f62375d3",
     "hint": null,
     "key": "app_exception_message",
@@ -274,7 +274,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because app exception takes precedence",
     "key": "system_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.913043+00:00'
+created: '2025-10-06T21:57:35.319326+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -172,7 +172,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "chained exception stacktraces — in-app frames",
     "hash": "c52ebcc2d9d0780a23c7d99831678830",
     "hint": null,
     "key": "app_chained_exception_stacktrace",
@@ -346,7 +346,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "chained exception stacktraces — all frames",
     "hash": "669cb6664e0f5fed38665da04e464f7e",
     "hint": null,
     "key": "system_chained_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_away_from_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.932035+00:00'
+created: '2025-10-06T21:57:35.336443+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "121caa876de75ec51bf72ed4c852cd75",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -1018,7 +1018,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "a5af2577d4caca8f983657c5d1919e14",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_grouping_enhancer_towards_crash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.951011+00:00'
+created: '2025-10-06T21:57:35.352634+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -508,7 +508,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -1018,7 +1018,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "90888e813b09fa25061af2883c0fb9bd",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/python_http_error.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.968542+00:00'
+created: '2025-10-06T21:57:35.368216+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -200,7 +200,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "d59239f5aad3304d60beb1fde3369b78",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -245,7 +245,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "default",
+    "description": "message",
     "hash": null,
     "hint": "ignored because app/system exception takes precedence",
     "key": "message",
@@ -447,7 +447,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "133db3f366b1327dab4e661f66dfb961",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.023888+00:00'
+created: '2025-10-06T19:13:34.784877+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -108,7 +108,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "chained error messages",
     "hash": "11e6467c8358a9366c6538f95dcd7bd4",
     "hint": null,
     "key": "app_chained_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_cause.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:47.984771+00:00'
+created: '2025-10-06T19:13:34.752947+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -67,7 +67,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "error message",
     "hash": "70dd09f56349dcce62a74137b00bb571",
     "hint": null,
     "key": "app_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_concurrent_rendering_no_mechanism.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.005821+00:00'
+created: '2025-10-06T19:13:34.769126+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -108,7 +108,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception",
+    "description": "chained error messages",
     "hash": "5f209162115f576bedbaf6f0ad30e5aa",
     "hint": null,
     "key": "app_chained_exception_message",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/react_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.045146+00:00'
+created: '2025-10-06T21:57:35.435236+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1023,7 +1023,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "73470e545e51eea9cff8a6c006f68f57",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -2048,7 +2048,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "ecd413627f0d90a5a25cb28d1ba9c39f",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_cocoa.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_cocoa.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.063168+00:00'
+created: '2025-10-06T21:57:35.450681+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -104,7 +104,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app stacktrace",
+    "description": "event-level stacktrace — in-app frames",
     "hash": "eb416f98479efa56a77c524602dc9979",
     "hint": null,
     "key": "app_stacktrace",
@@ -210,7 +210,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "1df786c8c266506e1acb6669c8df5154",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_collapse_recursion.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.080134+00:00'
+created: '2025-10-06T21:57:35.466478+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -287,7 +287,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -576,7 +576,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "9bdadae4fa003cef6cf460ff1325e54b",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.096185+00:00'
+created: '2025-10-06T21:57:35.481327+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -104,7 +104,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app stacktrace",
+    "description": "event-level stacktrace — in-app frames",
     "hash": "1effb24729ae4c43efa36b460511136a",
     "hint": null,
     "key": "app_stacktrace",
@@ -210,7 +210,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "659ad79e2e70c822d30a53d7d889529e",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_discards_seemingly_useless_stack.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.113144+00:00'
+created: '2025-10-06T21:57:35.497499+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -73,7 +73,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": null,
     "key": "app_stacktrace",
@@ -81,7 +81,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   },
   "fallback": {
     "contributes": true,
-    "description": "fallback",
+    "description": "fallback grouping",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
     "hint": null,
     "key": "fallback",
@@ -156,7 +156,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "event-level stacktrace — all frames",
     "hash": null,
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_discard_non_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.130252+00:00'
+created: '2025-10-06T21:57:35.512034+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -73,7 +73,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -148,7 +148,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "acbd18db4cc2f85cedef654fccc4a4d8",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_does_not_group_different_js_errors.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.146797+00:00'
+created: '2025-10-06T21:57:35.527962+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -73,7 +73,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": null,
     "key": "app_stacktrace",
@@ -81,7 +81,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   },
   "fallback": {
     "contributes": true,
-    "description": "fallback",
+    "description": "fallback grouping",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
     "hint": null,
     "key": "fallback",
@@ -156,7 +156,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "event-level stacktrace — all frames",
     "hash": null,
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_enforce_min_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.164325+00:00'
+created: '2025-10-06T21:57:35.544512+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -285,7 +285,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -572,7 +572,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "cb57cfc73cc622c2ac1386c9ea531fb9",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_excludes_single_frame_urls.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.182202+00:00'
+created: '2025-10-06T21:57:35.559749+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -75,7 +75,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -152,7 +152,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "cd2a9fd0cdaa8cd55ed22b101fc65882",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_hash_without_system_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.201403+00:00'
+created: '2025-10-06T21:57:35.574372+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -104,7 +104,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app stacktrace",
+    "description": "event-level stacktrace — in-app frames",
     "hash": "659ad79e2e70c822d30a53d7d889529e",
     "hint": null,
     "key": "app_stacktrace",
@@ -210,7 +210,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "event-level stacktrace — all frames",
     "hash": null,
     "hint": "ignored because app stacktrace takes precedence",
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_ignores_singular_anonymous_frame.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.221461+00:00'
+created: '2025-10-06T21:57:35.589662+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -139,7 +139,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "event-level stacktrace — in-app frames",
     "hash": null,
     "hint": "ignored because system stacktrace takes precedence",
     "key": "app_stacktrace",
@@ -280,7 +280,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "c5da56c71b31f34c5880d734cbc8f5bb",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_negated_match.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.240840+00:00'
+created: '2025-10-06T21:57:35.604946+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -285,7 +285,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "error message",
     "hash": null,
     "hint": "ignored because system exception takes precedence",
     "key": "app_exception_message",
@@ -572,7 +572,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "eb87c1031dba55b67df86fb9fff59dc6",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.258358+00:00'
+created: '2025-10-06T21:57:35.621660+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -285,7 +285,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "eb87c1031dba55b67df86fb9fff59dc6",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -572,7 +572,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "cb57cfc73cc622c2ac1386c9ea531fb9",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust2.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_rust2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.276941+00:00'
+created: '2025-10-06T21:57:35.638040+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -285,7 +285,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "eb87c1031dba55b67df86fb9fff59dc6",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -572,7 +572,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "0817e4e604fbe88c4534eff166df1db9",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/stacktrace_with_minimal_app_frames.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.295891+00:00'
+created: '2025-10-06T21:57:35.655241+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -414,7 +414,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app stacktrace",
+    "description": "event-level stacktrace — in-app frames",
     "hash": "1effb24729ae4c43efa36b460511136a",
     "hint": null,
     "key": "app_stacktrace",
@@ -830,7 +830,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "stacktrace",
+    "description": "event-level stacktrace — all frames",
     "hash": "659ad79e2e70c822d30a53d7d889529e",
     "hint": null,
     "key": "system_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/template_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/template_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.313858+00:00'
+created: '2025-10-06T19:13:35.034050+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -60,7 +60,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "template",
+    "description": "filename and context line",
     "hash": "1f5bdebe3c9f414c7dbb4296a8353245",
     "hint": null,
     "key": "template",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.331531+00:00'
+created: '2025-10-06T21:57:35.686604+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -83,7 +83,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app thread stacktrace",
+    "description": "thread stacktrace — in-app frames",
     "hash": "1a11687556cf74559f0ae90b1c87e2fd",
     "hint": null,
     "key": "app_thread_stacktrace",
@@ -168,7 +168,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "system",
+    "description": "thread stacktrace — all frames",
     "hash": null,
     "hint": "ignored because app threads take precedence",
     "key": "system_thread_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/threads_no_hash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.347995+00:00'
+created: '2025-10-06T21:57:35.701923+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -41,7 +41,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "in-app",
+    "description": "thread stacktrace — in-app frames",
     "hash": null,
     "hint": null,
     "key": "app_thread_stacktrace",
@@ -49,7 +49,7 @@ source: tests/sentry/grouping/test_grouping_info.py
   },
   "fallback": {
     "contributes": true,
-    "description": "fallback",
+    "description": "fallback grouping",
     "hash": "d41d8cd98f00b204e9800998ecf8427e",
     "hint": null,
     "key": "fallback",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unity.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.365700+00:00'
+created: '2025-10-06T21:57:35.718556+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -332,7 +332,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "a12d579fed7636c2a5d2fae110c95ce5",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -666,7 +666,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "c0dbeebf0430b3310ad1f7ceb48553a6",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assert_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assert_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.386478+00:00'
+created: '2025-10-06T21:57:35.736917+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1060,7 +1060,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "ecb890e5cd60dec2b626d500cc866de4",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -2122,7 +2122,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "57493ac3e558feffb778cf170a7fd986",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_android.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.405299+00:00'
+created: '2025-10-06T21:57:35.755112+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -808,7 +808,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "8c134ce2a43a0b2c55654902491307c2",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -1618,7 +1618,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "f203e9bc12df86bb01fbd92a45643f86",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_assertion_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.427577+00:00'
+created: '2025-10-06T21:57:35.774840+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1411,7 +1411,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "c246c95d4a435b3d601044aebae72a38",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -2824,7 +2824,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "d0669f63f03ddaec66ac8b9f4e3e449d",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.451315+00:00'
+created: '2025-10-06T21:57:35.795443+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -2850,7 +2850,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "e7a1be23aff9a117598bb893ed4bedb4",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -5702,7 +5702,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "1bba3ace796a07d167af26959c6039c9",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_ensure_check_fail_on_windows.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.474831+00:00'
+created: '2025-10-06T21:57:35.819046+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1636,7 +1636,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app exception stacktrace",
+    "description": "exception stacktrace — in-app frames",
     "hash": "4717aeb08ff642726ef6ea8f1ce55cdf",
     "hint": null,
     "key": "app_exception_stacktrace",
@@ -3274,7 +3274,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "exception stacktrace",
+    "description": "exception stacktrace — all frames",
     "hash": "65244b22630821cacd0be603ebcef671",
     "hint": null,
     "key": "system_exception_stacktrace",

--- a/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
+++ b/tests/sentry/grouping/snapshots/grouping_info/test_grouping_info/newstyle@2023_01_11/unreal_event_capture_mac.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2025-10-03T22:58:48.496229+00:00'
+created: '2025-10-06T21:57:35.837749+00:00'
 creator: sentry
 source: tests/sentry/grouping/test_grouping_info.py
 ---
@@ -1321,7 +1321,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "in-app thread stacktrace",
+    "description": "thread stacktrace — in-app frames",
     "hash": "54e8028fb2526cf31b12dd66c01ad9e2",
     "hint": null,
     "key": "app_thread_stacktrace",
@@ -1366,7 +1366,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": false,
-    "description": "default",
+    "description": "message",
     "hash": null,
     "hint": "ignored because app/system threads take precedence",
     "key": "message",
@@ -2689,7 +2689,7 @@ source: tests/sentry/grouping/test_grouping_info.py
       ]
     },
     "contributes": true,
-    "description": "thread stacktrace",
+    "description": "thread stacktrace — all frames",
     "hash": "9e04decaf79ecba9dc0314dc0edd3993",
     "hint": null,
     "key": "system_thread_stacktrace",


### PR DESCRIPTION
In the grouping info section of the issue details page, there are a number of problems with the way we describe grouping methods. In some cases, the description is incomplete (just `app` or just `system`, rather than `app _____` or `system _____`). In some cases, it's not very descriptive (`modified _____` to indicate a hybrid fingerprint, when we could be a lot more specific about what "modified" means). In some cases, it's unclear (`exception` and `exception stacktrace` are different, but it's easy to get them confused). And in some cases there's no method listed at all, and it just shows up as `default`.

The root of all of these problems is that the `description` property only looks at contributing components, and only "major" components at that. It's also directly reflective of the particular implementation of our grouping system, which works great for computation purposes, but less well for human understanding purposes. 

To fix these issues, this PR instead bases the description on a variant's key, which produces a different value for each possible grouping method, and which takes into account not only which components end up contributing to the final hash, but which components _would_ contribute if each variant were looked at individually. It also provides a human-readable translation for each key rather than just concatenating component names together.

Because grouphash metadata uses the `description` property in its computations, its implementation has been left alone for now. Instead, the new description is looked up only when creating the JSON for the grouping info section.

Examples of before and after heading values (not an exhaustive list):

```
In-app -> Error Message
In-app -> Exception Stacktrace — In-app Frames
In-app -> Event-level Stacktrace — In-app Frames
System -> Exception Stacktrace — All Frames
System -> Thread Stacktrace — All Frames
Default -> Message
In-app Exception -> NSError
In-app Exception -> Error Message
In-app Exception -> Error Type
Stacktrace -> Event-level Stacktrace — All Frames
Modified In-app Exception -> Error Message and Custom Fingerprint
```

---
*Copied from getsentry/sentry#101042*
*Original PR: https://github.com/getsentry/sentry/pull/101042*