### PR TITLE
feat(integrations): create audit logs for internal integration token changes

### DIFF
--- a/src/sentry/sentry_apps/api/endpoints/sentry_internal_app_token_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_internal_app_token_details.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, deletions
+from sentry import analytics, audit_log, deletions
 from sentry.analytics.events.sentry_app_installation_token_deleted import (
     SentryAppInstallationTokenDeleted,
 )
@@ -18,6 +18,7 @@ from sentry.sentry_apps.api.bases.sentryapps import (
 )
 from sentry.sentry_apps.api.endpoints.sentry_app_details import PARTNERSHIP_RESTRICTED_ERROR_MESSAGE
 from sentry.sentry_apps.models.sentry_app_installation_token import SentryAppInstallationToken
+from sentry.utils.audit import create_audit_entry
 
 
 @control_silo_endpoint
@@ -73,6 +74,13 @@ class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
                     sentry_app_installation_id=sentry_app_installation.id,
                     sentry_app=sentry_app.slug,
                 )
+            )
+            create_audit_entry(
+                request=request,
+                organization_id=sentry_app_installation.organization_id,
+                target_object=api_token.id,
+                event=audit_log.get_event_id("INTERNAL_INTEGRATION_REMOVE_TOKEN"),
+                data={"sentry_app": sentry_app.name},
             )
 
         return Response(status=204)

--- a/src/sentry/sentry_apps/api/endpoints/sentry_internal_app_tokens.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_internal_app_tokens.py
@@ -68,7 +68,7 @@ class SentryInternalAppTokensEndpoint(SentryAppBaseEndpoint):
                 request.user, (User, RpcUser)
             ), "User must be authenticated to install a sentry app"
             api_token = SentryAppInstallationTokenCreator(
-                sentry_app_installation=sentry_app_installation
+                sentry_app_installation=sentry_app_installation, generate_audit=True
             ).run(request=request, user=request.user)
         except ApiTokenLimitError as e:
             return Response(str(e), status=status.HTTP_403_FORBIDDEN)

--- a/src/sentry/sentry_apps/installations.py
+++ b/src/sentry/sentry_apps/installations.py
@@ -92,7 +92,7 @@ class SentryAppInstallationTokenCreator:
         if request and self.generate_audit:
             create_audit_entry(
                 request=request,
-                organization=self.organization_id,
+                organization_id=self.organization_id,
                 target_object=api_token.id,
                 event=audit_log.get_event_id("INTERNAL_INTEGRATION_ADD_TOKEN"),
                 data={"sentry_app": self.sentry_app.name},

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_tokens.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_tokens.py
@@ -1,8 +1,10 @@
 from django.test import override_settings
 from rest_framework import status
 
+from sentry import audit_log
 from sentry.models.apitoken import ApiToken
 from sentry.sentry_apps.models.sentry_app import MASKED_VALUE
+from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
@@ -35,7 +37,16 @@ class PostSentryInternalAppTokenTest(SentryInternalAppTokenTest):
             self.internal_sentry_app.slug, status_code=status.HTTP_201_CREATED
         )
 
-        assert ApiToken.objects.get(token=response.data["token"])
+        api_token = ApiToken.objects.get(token=response.data["token"])
+        assert api_token
+
+        # Verify audit log entry was created
+        assert_org_audit_log_exists(
+            organization=self.org,
+            event=audit_log.get_event_id("INTERNAL_INTEGRATION_ADD_TOKEN"),
+            target_object=api_token.id,
+            actor=self.user,
+        )
 
     def test_non_internal_app(self) -> None:
         sentry_app = self.create_sentry_app(name="My External App", organization=self.org)

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_tokens.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_internal_app_tokens.py
@@ -40,7 +40,6 @@ class PostSentryInternalAppTokenTest(SentryInternalAppTokenTest):
         api_token = ApiToken.objects.get(token=response.data["token"])
         assert api_token
 
-        # Verify audit log entry was created
         assert_org_audit_log_exists(
             organization=self.org,
             event=audit_log.get_event_id("INTERNAL_INTEGRATION_ADD_TOKEN"),


### PR DESCRIPTION
Create an audit log entry for when internal integration tokens are created or revoked.

Closes https://linear.app/getsentry/issue/RTC-29/audit-log-log-token-createsrevokes-on-custom-integrations

---
*Copied from getsentry/sentry#101041*
*Original PR: https://github.com/getsentry/sentry/pull/101041*