### PR TITLE
fix(project-creation): Should create 'other' project if no platform is selected

### DIFF
--- a/static/app/components/onboarding/useCreateProject.ts
+++ b/static/app/components/onboarding/useCreateProject.ts
@@ -7,10 +7,13 @@ import useApi from 'sentry/utils/useApi';
 import useOrganization from 'sentry/utils/useOrganization';
 
 interface Variables {
-  platform: OnboardingSelectedSDK;
   default_rules?: boolean;
   firstTeamSlug?: string;
   name?: string;
+  /**
+   * If no platform is provided, the project will be created with the 'other' platform
+   */
+  platform?: OnboardingSelectedSDK;
 }
 
 export function useCreateProject() {
@@ -26,7 +29,7 @@ export function useCreateProject() {
         {
           method: 'POST',
           data: {
-            platform: platform.key,
+            platform: platform?.key,
             name,
             default_rules: default_rules ?? true,
             origin: 'ui',

--- a/static/app/components/onboarding/useCreateProjectAndRules.ts
+++ b/static/app/components/onboarding/useCreateProjectAndRules.ts
@@ -16,8 +16,8 @@ type Variables = {
   createNotificationAction: ReturnType<
     typeof useCreateNotificationAction
   >['createNotificationAction'];
-  platform: OnboardingSelectedSDK;
   projectName: string;
+  platform?: OnboardingSelectedSDK;
   team?: string;
 };
 

--- a/static/app/types/onboarding.tsx
+++ b/static/app/types/onboarding.tsx
@@ -109,8 +109,8 @@ export interface UpdatedTask extends Partial<Pick<OnboardingTask, 'status' | 'da
 
 export interface OnboardingSelectedSDK
   extends Pick<PlatformIntegration, 'language' | 'link' | 'name' | 'type'> {
-  category: Category;
   key: PlatformKey;
+  category?: Category;
 }
 
 export type OnboardingRecentCreatedProject = {

--- a/static/app/utils/platform.tsx
+++ b/static/app/utils/platform.tsx
@@ -1,4 +1,3 @@
-import type {Platform} from 'sentry/components/platformPicker';
 import {
   backend,
   desktop,
@@ -8,7 +7,7 @@ import {
   PlatformCategory,
   serverless,
 } from 'sentry/data/platformCategories';
-import type {PlatformKey} from 'sentry/types/project';
+import type {PlatformIntegration, PlatformKey} from 'sentry/types/project';
 
 /**
  *
@@ -72,7 +71,7 @@ export function isDisabledGamingPlatform({
   platform,
   enabledConsolePlatforms,
 }: {
-  platform: Platform;
+  platform: PlatformIntegration;
   enabledConsolePlatforms?: string[];
 }) {
   return platform.type === 'console' && !enabledConsolePlatforms?.includes(platform.id);

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -455,5 +455,27 @@ describe('CreateProject', () => {
         })
       );
     });
+
+    it("should create 'other' platform if no platform is selected", async () => {
+      const {projectCreationMockRequest} = renderFrameworkModalMockRequests({
+        organization,
+        teamSlug: teamWithAccess.slug,
+      });
+      render(<CreateProject />, {organization});
+      expect(screen.getByRole('button', {name: 'Create Project'})).toBeDisabled();
+      await userEvent.type(screen.getByPlaceholderText('project-name'), 'my-project');
+      expect(screen.getByRole('button', {name: 'Create Project'})).toBeEnabled();
+      await userEvent.click(screen.getByRole('button', {name: 'Create Project'}));
+      expect(projectCreationMockRequest).toHaveBeenCalledWith(
+        `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
+        expect.objectContaining({
+          data: {
+            default_rules: true,
+            name: 'my-project',
+            origin: 'ui',
+          },
+        })
+      );
+    });
   });
 });


### PR DESCRIPTION
**Problem**
Previously, we disabled users from creating 'other' platforms, but this was later reverted. However, we missed reverting a validation in project creation that blocks users from proceeding if they don’t explicitly select a platform - they could choose 'other', for example.


<img width="1343" height="389" alt="image" src="https://github.com/user-attachments/assets/3e44b05a-6bd7-4962-a595-2958fd385bda" />



**Solution**
This PR reverts that validation, so if no platform is selected, an 'other' platform is created automatically as it was before ([see](https://github.com/getsentry/sentry/blame/e729f6741dde1cecb3c4d3527c76560e82f483ed/static/app/views/projectInstall/createProject.tsx#L132)).



https://github.com/user-attachments/assets/15e9622f-df77-4329-a258-a113c7a6c8a7



closes https://linear.app/getsentry/issue/TET-1248/project-creation-make-sure-button-is-deactivated-when-platform-is

---
*Copied from getsentry/sentry#101059*
*Original PR: https://github.com/getsentry/sentry/pull/101059*