### PR TITLE
ref: stabilize flaky replay test

### DIFF
--- a/static/app/utils/replayCount/useReplayCount.spec.tsx
+++ b/static/app/utils/replayCount/useReplayCount.spec.tsx
@@ -49,7 +49,7 @@ describe('useReplayCount', () => {
         );
       });
 
-      expect(result.current.getOne('1111')).toBe(5);
+      await waitFor(() => expect(result.current.getOne('1111')).toBe(5));
       expect(result.current.getOne('2222')).toBe(7);
       expect(result.current.getOne('3333')).toBe(0);
       expect(result.current.hasOne('1111')).toBeTruthy();
@@ -82,7 +82,7 @@ describe('useReplayCount', () => {
         );
       });
 
-      expect(result.current.getOne('1111')).toBe(0);
+      await waitFor(() => expect(result.current.getOne('1111')).toBe(0));
       expect(result.current.getOne('2222')).toBe(7);
       expect(result.current.hasOne('1111')).toBeFalsy();
       expect(result.current.hasOne('2222')).toBeTruthy();
@@ -115,11 +115,13 @@ describe('useReplayCount', () => {
         );
       });
 
-      expect(result.current.getMany(['1111', '2222', '3333'])).toStrictEqual({
-        '1111': 5,
-        '2222': 7,
-        '3333': 0,
-      });
+      await waitFor(() =>
+        expect(result.current.getMany(['1111', '2222', '3333'])).toStrictEqual({
+          '1111': 5,
+          '2222': 7,
+          '3333': 0,
+        })
+      );
       expect(result.current.hasMany(['1111', '2222', '3333'])).toStrictEqual({
         '1111': true,
         '2222': true,
@@ -150,10 +152,12 @@ describe('useReplayCount', () => {
         );
       });
 
-      expect(result.current.getMany(['1111', '2222'])).toStrictEqual({
-        '1111': 0,
-        '2222': 7,
-      });
+      await waitFor(() =>
+        expect(result.current.getMany(['1111', '2222'])).toStrictEqual({
+          '1111': 0,
+          '2222': 7,
+        })
+      );
       expect(result.current.hasMany(['1111', '2222'])).toStrictEqual({
         '1111': false,
         '2222': true,


### PR DESCRIPTION
These tests have been flaky in CI for quite some time, and I got some failures again today:

- https://github.com/getsentry/sentry/actions/runs/18309863874/job/52135698814?pr=101060

I _think_ the issue is that awaiting the network request does not guarantee that the component has re-rendered, so `.getOne` and `.getMany` might still have an old reference and read stale values in CI where the machines have less power and are under more load. Locally, it always passes either way.

The “fix” here is to take the first expectation after awaiting the network request and also wrap it in an `await waitFor(...)` so that it automatically retries if the first attempt fails.

Note that all further calls can be kept synchronously because if the first one succeeds, the others should too.

---
*Copied from getsentry/sentry#101062*
*Original PR: https://github.com/getsentry/sentry/pull/101062*