### PR TITLE
fix(ui): always render tabs in insights/ai to avoid flash during first navigation

### DIFF
--- a/static/app/routes.tsx
+++ b/static/app/routes.tsx
@@ -1999,6 +1999,7 @@ function buildRoutes(): RouteObject[] {
       children: [
         {
           index: true,
+          handle: {module: ModuleName.AGENTS},
           component: make(() => import('sentry/views/insights/agents/views/overview')),
         },
       ],
@@ -2008,6 +2009,7 @@ function buildRoutes(): RouteObject[] {
       children: [
         {
           index: true,
+          handle: {module: ModuleName.MCP},
           component: make(() => import('sentry/views/insights/mcp/views/overview')),
         },
       ],
@@ -2080,6 +2082,7 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: `${AGENTS_LANDING_SUB_PATH}/`,
+      component: make(() => import('sentry/views/insights/pages/agents/layout')),
       children: [
         {
           index: true,

--- a/static/app/views/insights/agents/views/overview.tsx
+++ b/static/app/views/insights/agents/views/overview.tsx
@@ -52,8 +52,6 @@ import OverviewAgentsDurationChartWidget from 'sentry/views/insights/common/comp
 import OverviewAgentsRunsChartWidget from 'sentry/views/insights/common/components/widgets/overviewAgentsRunsChartWidget';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {useDefaultToAllProjects} from 'sentry/views/insights/common/utils/useDefaultToAllProjects';
-import {AgentsPageHeader} from 'sentry/views/insights/pages/agents/agentsPageHeader';
-import {getAIModuleTitle} from 'sentry/views/insights/pages/agents/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 
 const TableControl = SegmentedControl<TableType>;
@@ -157,10 +155,6 @@ function AgentsOverviewPage() {
 
   return (
     <SearchQueryBuilderProvider {...eapSpanSearchQueryProviderProps}>
-      <AgentsPageHeader
-        module={ModuleName.AGENTS}
-        headerTitle={<Fragment>{getAIModuleTitle(organization)}</Fragment>}
-      />
       <ModuleFeature moduleName={ModuleName.AGENTS}>
         <Layout.Body>
           <Layout.Main fullWidth>

--- a/static/app/views/insights/mcp/views/overview.tsx
+++ b/static/app/views/insights/mcp/views/overview.tsx
@@ -50,8 +50,6 @@ import McpTrafficByClientWidget from 'sentry/views/insights/mcp/components/mcpTr
 import McpTransportWidget from 'sentry/views/insights/mcp/components/mcpTransportWidget';
 import {WidgetGrid} from 'sentry/views/insights/mcp/components/styles';
 import {Onboarding} from 'sentry/views/insights/mcp/views/onboarding';
-import {AgentsPageHeader} from 'sentry/views/insights/pages/agents/agentsPageHeader';
-import {getAIModuleTitle} from 'sentry/views/insights/pages/agents/settings';
 import {ModuleName} from 'sentry/views/insights/types';
 
 const TableControl = SegmentedControl<ViewType>;
@@ -197,10 +195,6 @@ function McpOverviewPage() {
 
   return (
     <SearchQueryBuilderProvider {...eapSpanSearchQueryProviderProps}>
-      <AgentsPageHeader
-        module={ModuleName.MCP}
-        headerTitle={<Fragment>{getAIModuleTitle(organization)}</Fragment>}
-      />
       <ModuleFeature moduleName={ModuleName.MCP}>
         <Layout.Body>
           <Layout.Main fullWidth>

--- a/static/app/views/insights/pages/agents/layout.tsx
+++ b/static/app/views/insights/pages/agents/layout.tsx
@@ -1,0 +1,18 @@
+import {Fragment} from 'react';
+import {Outlet, useMatches} from 'react-router-dom';
+
+import {AgentsPageHeader} from 'sentry/views/insights/pages/agents/agentsPageHeader';
+import {ModuleName} from 'sentry/views/insights/types';
+
+function AgentsLayout() {
+  const handle = useMatches().at(-1)?.handle as {module?: ModuleName} | undefined;
+
+  return (
+    <Fragment>
+      {handle && 'module' in handle ? <AgentsPageHeader module={handle.module} /> : null}
+      <Outlet />
+    </Fragment>
+  );
+}
+
+export default AgentsLayout;


### PR DESCRIPTION


---
*Copied from getsentry/sentry#101068*
*Original PR: https://github.com/getsentry/sentry/pull/101068*